### PR TITLE
[FEAT] 로그인/회원가입, 토큰 재발급, 유저 본인 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,12 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'mysql:mysql-connector-java'
+
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/server/sookdak/api/UserApi.java
+++ b/src/main/java/server/sookdak/api/UserApi.java
@@ -1,0 +1,46 @@
+package server.sookdak.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import server.sookdak.dto.TokenDto;
+import server.sookdak.dto.req.TokenRequestDto;
+import server.sookdak.dto.res.TokenResponse;
+import server.sookdak.dto.res.UserResponse;
+import server.sookdak.dto.res.UserResponseDto;
+import server.sookdak.dto.req.UserRequestDto;
+import server.sookdak.service.UserService;
+
+import javax.validation.Valid;
+
+import static server.sookdak.constants.SuccessCode.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserApi {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<UserResponseDto> getMyMemberInfo() {
+        UserResponseDto userResponseDto = userService.getMyInfo();
+        return UserResponse.toResponse(USER_INFO_SUCCESS, userResponseDto);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@Valid @RequestBody UserRequestDto userRequestDto) {
+        TokenDto tokenDto = userService.login(userRequestDto);
+        if (tokenDto == null) {
+            return TokenResponse.toResponse(SIGNUP_SUCCESS, null);
+        }
+
+        return TokenResponse.toResponse(LOGIN_SUCCESS, tokenDto);
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenResponse> reissue(@Valid @RequestBody TokenRequestDto tokenRequestDto) {
+        TokenDto tokenDto = userService.reissue(tokenRequestDto);
+        return TokenResponse.toResponse(REISSUE_SUCCESS, tokenDto);
+    }
+}

--- a/src/main/java/server/sookdak/api/api.java
+++ b/src/main/java/server/sookdak/api/api.java
@@ -1,4 +1,0 @@
-package server.sookdak.api;
-
-public class api {
-}

--- a/src/main/java/server/sookdak/config/JwtSecurityConfig.java
+++ b/src/main/java/server/sookdak/config/JwtSecurityConfig.java
@@ -1,0 +1,22 @@
+package server.sookdak.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import server.sookdak.jwt.JwtFilter;
+import server.sookdak.jwt.TokenProvider;
+
+//직접 만든 TokenProvider와 JwtFilter를 SecurityConfig에 적용할 때 사용
+@RequiredArgsConstructor
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+    private final TokenProvider tokenProvider;
+
+    //TokenProvider를 주입받아서 JwtFilter를 통해 Security 로직에 필터 등록
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        JwtFilter customFilter = new JwtFilter(tokenProvider);
+        http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/server/sookdak/config/SecurityConfig.java
+++ b/src/main/java/server/sookdak/config/SecurityConfig.java
@@ -1,0 +1,52 @@
+package server.sookdak.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import server.sookdak.jwt.JwtAccessDeniedHandler;
+import server.sookdak.jwt.JwtAuthenticationEntryPoint;
+import server.sookdak.jwt.TokenProvider;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final TokenProvider tokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+
+                // exception handling 할 때 만든 클래스 추가
+                .exceptionHandling()
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .accessDeniedHandler(jwtAccessDeniedHandler)
+
+                // 세션을 사용하지 않기 때문에 STATELESS로 설정
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+                .and()
+                .authorizeRequests()
+                .antMatchers("/api/user/**").permitAll() //인증 없이 접근 허용
+                .anyRequest().authenticated() //나머지 요청은 모두 인증 필요
+
+                //JwtFilter를 addFilterBefore로 등록했던 JwtSecurityConfig 클래스 적용
+                .and()
+                .apply(new JwtSecurityConfig(tokenProvider));
+    }
+}

--- a/src/main/java/server/sookdak/constants/ExceptionCode.java
+++ b/src/main/java/server/sookdak/constants/ExceptionCode.java
@@ -1,0 +1,30 @@
+package server.sookdak.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@AllArgsConstructor
+public enum ExceptionCode {
+    // token 관련
+    WRONG_TYPE_TOKEN(UNAUTHORIZED, "잘못된 JWT 서명을 가진 토큰입니다."),
+    EXPIRED_TOKEN(UNAUTHORIZED, "만료된 JWT 토큰입니다."),
+    UNSUPPORTED_TOKEN(UNAUTHORIZED, "지원되지 않는 JWT 토큰입니다."),
+    WRONG_TOKEN(UNAUTHORIZED, "JWT 토큰이 잘못되었습니다."),
+    UNKNOWN_ERROR(UNAUTHORIZED, "알 수 없는 요청 인증 에러! 헤더에 토큰을 넣어 보냈는지 다시 한 번 확인해보세요."),
+    ACCESS_DENIED(UNAUTHORIZED, "접근이 거절되었습니다."),
+    USER_NOT_FOUND(UNAUTHORIZED, "로그인 유저 정보가 없습니다.")
+
+    /* 403 - 허용되지 않은 접근 */,
+    FORBIDDEN_ACCESS(FORBIDDEN, "허용되지 않은 접근입니다."),
+    SOOKMYUNG_ONLY(FORBIDDEN, "숙명 계정으로 로그인해야 합니다."),
+
+    /* 404 - 찾을 수 없는 리소스 */
+    MEMBER_EMAIL_NOT_FOUND(NOT_FOUND, "가입되지 않은 이메일입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -1,0 +1,19 @@
+package server.sookdak.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessCode {
+    SIGNUP_SUCCESS(OK, "회원가입을 완료했습니다."),
+    LOGIN_SUCCESS(OK, "로그인에 성공했습니다."),
+    USER_INFO_SUCCESS(OK, "유저 조회에 성공했습니다."),
+    REISSUE_SUCCESS(OK, "토큰 재발급에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/server/sookdak/domain/Authority.java
+++ b/src/main/java/server/sookdak/domain/Authority.java
@@ -1,0 +1,7 @@
+package server.sookdak.domain;
+
+import lombok.*;
+
+public enum Authority {
+    ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/java/server/sookdak/domain/User.java
+++ b/src/main/java/server/sookdak/domain/User.java
@@ -1,0 +1,40 @@
+package server.sookdak.domain;
+
+import com.sun.istack.NotNull;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @Column(name = "user_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @NotNull
+    @Column(length = 100)
+    private String email;
+
+    private String password;
+
+    private String refreshToken;
+
+    @Enumerated(EnumType.STRING)
+    private Authority authority;
+
+    public static User createUser(String email, String password, Authority authority) {
+        User user = new User();
+        user.email = email;
+        user.password = password;
+        user.authority = authority;
+        return user;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/server/sookdak/domain/domain.java
+++ b/src/main/java/server/sookdak/domain/domain.java
@@ -1,4 +1,0 @@
-package server.sookdak.domain;
-
-public class domain {
-}

--- a/src/main/java/server/sookdak/dto/BaseResponse.java
+++ b/src/main/java/server/sookdak/dto/BaseResponse.java
@@ -1,0 +1,46 @@
+package server.sookdak.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.ExceptionCode;
+import server.sookdak.constants.SuccessCode;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class BaseResponse {
+
+    private Boolean succcess;
+    private String message;
+    private LocalDateTime timestamp = LocalDateTime.now();
+
+    public BaseResponse(Boolean success, String message) {
+        this.succcess = success;
+        this.message = message;
+    }
+
+    public static BaseResponse of(Boolean success, String message) {
+        return new BaseResponse(success, message);
+    }
+
+    public static ResponseEntity<BaseResponse> toCustomErrorResponse(ExceptionCode exceptionCode) {
+        return ResponseEntity
+                .status(exceptionCode.getStatus())
+                .body(BaseResponse.of(false, exceptionCode.getMessage()));
+    }
+
+    public static ResponseEntity<BaseResponse> toBasicErrorResponse(HttpStatus status, String message) {
+        return ResponseEntity
+                .status(status)
+                .body(BaseResponse.of(false, message));
+    }
+
+    public static ResponseEntity<BaseResponse> toSuccessResponse(SuccessCode successCode) {
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(BaseResponse.of(true, successCode.getMessage()));
+    }
+}

--- a/src/main/java/server/sookdak/dto/TokenDto.java
+++ b/src/main/java/server/sookdak/dto/TokenDto.java
@@ -1,0 +1,23 @@
+package server.sookdak.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TokenDto {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+    private Long accessTokenExpiresIn;
+
+    public static TokenDto of(String grantType, String accessToken, String refreshToken, Long accessTokenExpiresIn) {
+        TokenDto tokenDto = new TokenDto();
+        tokenDto.grantType = grantType;
+        tokenDto.accessToken = accessToken;
+        tokenDto.refreshToken = refreshToken;
+        tokenDto.accessTokenExpiresIn = accessTokenExpiresIn;
+        return tokenDto;
+    }
+}

--- a/src/main/java/server/sookdak/dto/dto.java
+++ b/src/main/java/server/sookdak/dto/dto.java
@@ -1,4 +1,0 @@
-package server.sookdak.dto;
-
-public class dto {
-}

--- a/src/main/java/server/sookdak/dto/req/TokenRequestDto.java
+++ b/src/main/java/server/sookdak/dto/req/TokenRequestDto.java
@@ -1,0 +1,11 @@
+package server.sookdak.dto.req;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenRequestDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/server/sookdak/dto/req/UserRequestDto.java
+++ b/src/main/java/server/sookdak/dto/req/UserRequestDto.java
@@ -1,0 +1,23 @@
+package server.sookdak.dto.req;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import server.sookdak.domain.Authority;
+import server.sookdak.domain.User;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserRequestDto {
+    private String email;
+
+    public User toUser(PasswordEncoder passwordEncoder, String key) {
+        return User.createUser(email, passwordEncoder.encode(key), Authority.ROLE_USER);
+    }
+
+    public UsernamePasswordAuthenticationToken toAuthentication(String key) {
+        return new UsernamePasswordAuthenticationToken(email, key);
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/TokenResponse.java
+++ b/src/main/java/server/sookdak/dto/res/TokenResponse.java
@@ -1,0 +1,25 @@
+package server.sookdak.dto.res;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+import server.sookdak.dto.TokenDto;
+
+@Getter
+@NoArgsConstructor
+public class TokenResponse extends BaseResponse {
+    private TokenDto data;
+
+    private TokenResponse(Boolean success, String message, TokenDto data) {
+        super(success, message);
+        this.data = data;
+    }
+
+    public static ResponseEntity<TokenResponse> toResponse(SuccessCode code, TokenDto data){
+        TokenResponse response = new TokenResponse(true, code.getMessage(), data);
+        return new ResponseEntity(response, code.getStatus());
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/UserResponse.java
+++ b/src/main/java/server/sookdak/dto/res/UserResponse.java
@@ -1,0 +1,23 @@
+package server.sookdak.dto.res;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+
+@Getter
+@NoArgsConstructor
+public class UserResponse extends BaseResponse {
+    private UserResponseDto data;
+
+    private UserResponse(Boolean success, String message, UserResponseDto data) {
+        super(success, message);
+        this.data = data;
+    }
+
+    public static ResponseEntity<UserResponseDto> toResponse(SuccessCode code, UserResponseDto data) {
+        UserResponse response = new UserResponse(true, code.getMessage(), data);
+        return new ResponseEntity(response, code.getStatus());
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/UserResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/UserResponseDto.java
@@ -1,0 +1,20 @@
+package server.sookdak.dto.res;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.sookdak.domain.Authority;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserResponseDto {
+    private String email;
+    private Authority authority;
+
+    public static UserResponseDto toUserResponseDto(String email, Authority authority) {
+        UserResponseDto userDto = new UserResponseDto();
+        userDto.email = email;
+        userDto.authority = authority;
+        return userDto;
+    }
+}

--- a/src/main/java/server/sookdak/exception/CustomException.java
+++ b/src/main/java/server/sookdak/exception/CustomException.java
@@ -1,0 +1,11 @@
+package server.sookdak.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import server.sookdak.constants.ExceptionCode;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+    private final ExceptionCode exceptionCode;
+}

--- a/src/main/java/server/sookdak/exception/RestExceptionHandler.java
+++ b/src/main/java/server/sookdak/exception/RestExceptionHandler.java
@@ -1,0 +1,20 @@
+package server.sookdak.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import server.sookdak.dto.BaseResponse;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Slf4j
+@RestControllerAdvice
+public class RestExceptionHandler {
+
+    @ExceptionHandler(value = { CustomException.class })
+    protected ResponseEntity<BaseResponse> handleCustomException(CustomException e, HttpServletRequest request) {
+        log.warn(String.format("[%s Error] : %s %s", e.getExceptionCode().getStatus(), request.getMethod(), request.getRequestURI()));
+        return BaseResponse.toCustomErrorResponse(e.getExceptionCode());
+    }
+}

--- a/src/main/java/server/sookdak/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/server/sookdak/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,39 @@
+package server.sookdak.jwt;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import server.sookdak.constants.ExceptionCode;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        log.warn("================================================================");
+        log.warn("User(" + auth.getName() + ") 가 접근 제한이 걸려있는 URL에 접근했습니다.");
+        log.warn("PROTECTED : " + request.getRequestURI());
+        log.warn("================================================================");
+        setResponse(response, ExceptionCode.FORBIDDEN_ACCESS);
+        return;
+    }
+
+    private void setResponse(HttpServletResponse response, ExceptionCode exceptionCode) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.getWriter().println("{ \"success\" : false, \"message\" : \"" + exceptionCode.getMessage()
+                + "\", \"timestamp\" : \"" + LocalDateTime.now() + "\" \n }");
+    }
+}

--- a/src/main/java/server/sookdak/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/server/sookdak/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,47 @@
+package server.sookdak.jwt;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import server.sookdak.constants.ExceptionCode;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+import static server.sookdak.constants.ExceptionCode.*;
+
+@Slf4j
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        String exception = String.valueOf(request.getAttribute("exception"));
+
+        if (exception == null) {
+            log.info("알 수 없는 인증 에러입니다.");
+            setResponse(response, UNKNOWN_ERROR);
+        } else if (exception.equals("WRONG_TYPE_TOKEN")) {
+            setResponse(response, WRONG_TYPE_TOKEN);
+        } else if (exception.equals("EXPIRED_TOKEN")) {
+            setResponse(response, EXPIRED_TOKEN);
+        } else if (exception.equals("UNSUPPORTED_TOKEN")) {
+            setResponse(response, UNSUPPORTED_TOKEN);
+        } else {
+            setResponse(response, ACCESS_DENIED);
+        }
+        return;
+    }
+
+    private void setResponse(HttpServletResponse response, ExceptionCode exceptionCode) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        response.getWriter().println("{ \"success\" : false, \"message\" : \"" + exceptionCode.getMessage()
+                + "\", \"timestamp\" : \"" + LocalDateTime.now() + "\" \n }");
+    }
+}

--- a/src/main/java/server/sookdak/jwt/JwtFilter.java
+++ b/src/main/java/server/sookdak/jwt/JwtFilter.java
@@ -1,0 +1,81 @@
+package server.sookdak.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import server.sookdak.exception.CustomException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static server.sookdak.constants.ExceptionCode.*;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final TokenProvider tokenProvider;
+
+    //토큰의 인증정보를 현재 실행 중인 SecurityContext에 저장하는 역할 수행
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        // 1. Request Header 에서 토큰을 꺼냄
+        String jwt = resolveToken(request);
+
+        // 2. validateToken 으로 토큰 유효성 검사
+        // 정상 토큰이면 해당 토큰으로 Authentication 을 가져와서 SecurityContext 에 저장
+        try{
+            if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+                Authentication authentication = tokenProvider.getAuthentication(jwt);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            request.setAttribute("exception", WRONG_TYPE_TOKEN);
+            log.info("잘못된 JWT 서명입니다.");
+            throw new CustomException(WRONG_TYPE_TOKEN);
+        } catch (ExpiredJwtException e) {
+            request.setAttribute("exception", EXPIRED_TOKEN);
+            log.info("만료된 JWT 토큰입니다.");
+            throw new CustomException(EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            request.setAttribute("exception", UNSUPPORTED_TOKEN);
+            log.info("지원되지 않는 JWT 토큰입니다.");
+            throw new CustomException(UNSUPPORTED_TOKEN);
+        } catch (IllegalArgumentException e) {
+            request.setAttribute("exception", WRONG_TOKEN);
+            log.info("JWT 토큰이 잘못되었습니다.");
+            throw new CustomException(WRONG_TOKEN);
+        } catch(Exception e) {
+            log.error("===========================================");
+            log.error("JwtFilter - doFilterInternal() 오류 발생");
+            log.error("Exception message : {}", e.getMessage());
+            log.error("===========================================");
+            request.setAttribute("exception", UNKNOWN_ERROR);
+            throw new CustomException(UNKNOWN_ERROR);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    //Request Header에서 토큰 정보 꺼내오기
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}
+

--- a/src/main/java/server/sookdak/jwt/TokenProvider.java
+++ b/src/main/java/server/sookdak/jwt/TokenProvider.java
@@ -1,0 +1,102 @@
+package server.sookdak.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import server.sookdak.dto.TokenDto;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class TokenProvider {
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final String BEARER_TYPE = "bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60;            // 1시간
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14;  // 2주
+
+    private final Key key;
+
+    public TokenProvider(@Value("${jwt.secret}") String secret) {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    //Authentication 객체의 권한 정보를 이용해서 토큰 생성
+    public TokenDto generateTokenDto(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        Long now = (new Date()).getTime();
+
+        // Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())       // payload "sub": "name"
+                .claim(AUTHORITIES_KEY, authorities)        // payload "auth": "ROLE_USER"
+                .setExpiration(accessTokenExpiresIn)        // payload "exp": 1516239022 (예시)
+                .signWith(key, SignatureAlgorithm.HS512)    // header "alg": "HS512"
+                .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+
+        return TokenDto.of(BEARER_TYPE, accessToken, refreshToken, accessTokenExpiresIn.getTime());
+    }
+
+    //token에 담겨있는 정보를 이용해 Authentication 객체를 리턴
+    public Authentication getAuthentication(String accessToken) {
+        // 토큰 복호화
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get(AUTHORITIES_KEY) == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        // 클레임에서 권한 정보 가져오기
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        // UserDetails 객체를 만들어서 Authentication 리턴
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, accessToken, authorities);
+    }
+
+    //token의 유효성 검증 수행
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/server/sookdak/repository/UserRepository.java
+++ b/src/main/java/server/sookdak/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package server.sookdak.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.sookdak.domain.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/server/sookdak/repository/repository.java
+++ b/src/main/java/server/sookdak/repository/repository.java
@@ -1,4 +1,0 @@
-package server.sookdak.repository;
-
-public class repository {
-}

--- a/src/main/java/server/sookdak/service/CustomUserDetailsService.java
+++ b/src/main/java/server/sookdak/service/CustomUserDetailsService.java
@@ -1,0 +1,38 @@
+package server.sookdak.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.sookdak.domain.User;
+import server.sookdak.repository.UserRepository;
+
+import java.util.Collections;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByEmail(email)
+                .map(this::createUserDetails)
+                .orElseThrow(() -> new UsernameNotFoundException(email + " -> 데이터베이스에서 찾을 수 없습니다."));
+    }
+
+    private UserDetails createUserDetails(User user) {
+        SimpleGrantedAuthority grantedAuthority = new SimpleGrantedAuthority(user.getAuthority().toString());
+
+        return new org.springframework.security.core.userdetails.User(
+                String.valueOf(user.getEmail()),
+                user.getPassword(),
+                Collections.singleton(grantedAuthority)
+        );
+    }
+}

--- a/src/main/java/server/sookdak/service/UserService.java
+++ b/src/main/java/server/sookdak/service/UserService.java
@@ -1,0 +1,99 @@
+package server.sookdak.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.sookdak.constants.ExceptionCode;
+import server.sookdak.domain.User;
+import server.sookdak.dto.TokenDto;
+import server.sookdak.dto.req.TokenRequestDto;
+import server.sookdak.dto.req.UserRequestDto;
+import server.sookdak.dto.res.UserResponseDto;
+import server.sookdak.exception.CustomException;
+import server.sookdak.jwt.TokenProvider;
+import server.sookdak.repository.UserRepository;
+import server.sookdak.util.SecurityUtil;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final PasswordEncoder passwordEncoder;
+    @Value("${jwt.key}")
+    private String key;
+
+
+    //현재 SecurityContext에 있는 유저 정보 가져오기
+    public UserResponseDto getMyInfo() {
+        String userEmail = SecurityUtil.getCurrentUserEmail();
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND));
+        return UserResponseDto.toUserResponseDto(userEmail, user.getAuthority());
+    }
+
+    public TokenDto login(UserRequestDto userRequestDto) {
+        if (!(userRequestDto.getEmail().contains("sookmyung.ac.kr") || userRequestDto.getEmail().contains("sm.ac.kr"))) {
+            throw new CustomException(ExceptionCode.SOOKMYUNG_ONLY);
+        }
+        if (!userRepository.existsByEmail(userRequestDto.getEmail())) {
+            // signup
+            User user = userRequestDto.toUser(passwordEncoder, key);
+            userRepository.save(user);
+            return null;
+        }
+
+        //1. AuthenticationToken 생성
+        UsernamePasswordAuthenticationToken authenticationToken = userRequestDto.toAuthentication(key);
+
+        //2. 검증 이뤄짐
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        //3. 인증 정보 기반으로 JWT 토큰 생성
+        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
+
+        //4. refreshToken 저장
+        User user = userRepository.findByEmail(userRequestDto.getEmail()).get();
+        user.setRefreshToken(tokenDto.getRefreshToken());
+
+        //5. 토큰 발급
+        return tokenDto;
+    }
+
+    public TokenDto reissue(TokenRequestDto tokenRequestDto) {
+        //1. refreshToken 검증
+        if (!tokenProvider.validateToken(tokenRequestDto.getRefreshToken())) {
+            throw new RuntimeException("Refresh Token이 유효하지 않습니다.");
+        }
+
+        //2. AccessToken에서 UserId 가져오기
+        Authentication authentication = tokenProvider.getAuthentication(tokenRequestDto.getAccessToken());
+
+        //3. 저장소에서 UserId 기반으로 RefreshToken 값 가져오기
+        User user = userRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new RuntimeException("로그아웃 된 사용자입니다."));
+        String refreshToken = user.getRefreshToken();
+
+        //4. Refresh Token 일치하는지 검사
+        if (!refreshToken.equals(tokenRequestDto.getRefreshToken())) {
+            throw new RuntimeException("토큰의 유저 정보가 일치하지 않습니다.");
+        }
+
+        //5. 새로운 토큰 생성
+        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
+
+        //6. 저장소 정보 업데이트
+        user.setRefreshToken(tokenDto.getRefreshToken());
+
+        //7. 토큰 발급
+        return tokenDto;
+    }
+}

--- a/src/main/java/server/sookdak/service/service.java
+++ b/src/main/java/server/sookdak/service/service.java
@@ -1,4 +1,0 @@
-package server.sookdak.service;
-
-public class service {
-}

--- a/src/main/java/server/sookdak/util/SecurityUtil.java
+++ b/src/main/java/server/sookdak/util/SecurityUtil.java
@@ -1,0 +1,26 @@
+package server.sookdak.util;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import server.sookdak.constants.ExceptionCode;
+import server.sookdak.exception.CustomException;
+
+public class SecurityUtil {
+
+    private SecurityUtil() {
+    }
+
+    //SecurityContext의 Authentication 객체를 이용해 email 리턴
+    public static String getCurrentUserEmail() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getName() == null) {
+            throw new RuntimeException("Security Context에 인증 정보가 없습니다.");
+        }
+        if (authentication.getName().equals("anonymousUser")) {
+            throw new CustomException(ExceptionCode.ACCESS_DENIED);
+        }
+
+        return authentication.getName();
+    }
+}


### PR DESCRIPTION
## 작업사항
API 3가지 개발했습니다..
노션에 API 명세서 들어가면 API에 관한 설명 써뒀어~~ 나중에 API 개발하고 명세서 쓰면 되는데 템플릿 추가해서 쓰는 법 알려줄게
jwt token 사용해서 로그인 하는 로직도 노션 API 명세서 쪽에 올려뒀으니 참고 바랍니다.. 포스트맨에서 jwt 편하게 사용하는 법두 노션에..
그리고 내가 이번에 예외 처리 하는 부분을 ExceptionHandler로 사용해봤는데 이거 쫌 어려울 수 있거든 한 번 구글링해서 공부해보고 어려우면 예외처리하는 부분은 일단 빼고 코딩한 다음에 나중에 Handler로 예외 처리 잡는 코드 추가해도 돼!! 공부하면서 천천히 해봐바 급하지 않으니께

코드 찬찬히 살펴보고 approve 부탁드립니다....~~~
closed #3 

## 테스트
### 회원가입 SUCCESS
<img width="746" alt="스크린샷 2022-03-27 오후 12 48 59" src="https://user-images.githubusercontent.com/73515587/160266664-a74a24e3-332b-4846-bf32-0e2700982a64.png">

### 로그인 SUCCESS
<img width="746" alt="스크린샷 2022-03-27 오후 12 49 19" src="https://user-images.githubusercontent.com/73515587/160266669-3de2328f-9d42-44a6-84c5-f19360f78fbe.png">

### 로그인 FAIL - 숙명 계정 아닐 때
<img width="746" alt="스크린샷 2022-03-27 오후 1 01 13" src="https://user-images.githubusercontent.com/73515587/160266672-d2f2b788-08f5-4c86-8be7-56d69853196c.png">

### 토큰 재발급 SUCCESS
<img width="746" alt="스크린샷 2022-03-27 오후 12 49 36" src="https://user-images.githubusercontent.com/73515587/160266679-2679f10a-db98-4920-866a-bfa590102b0b.png">

### 유저 조회(본인) SUCCESS
<img width="746" alt="스크린샷 2022-03-27 오후 12 54 04" src="https://user-images.githubusercontent.com/73515587/160266690-bd833449-055d-4ec4-8df1-3ca7c37c89c2.png">

### 유저 조회(본인) FAIL - 헤더에 토큰 없을 때
<img width="746" alt="스크린샷 2022-03-27 오후 12 50 00" src="https://user-images.githubusercontent.com/73515587/160266696-f10d4165-f83a-4220-9d39-5b9ff6114ad6.png">

### 유저 조회(본인) FAIL - 토큰 만료 시
<img width="746" alt="스크린샷 2022-03-27 오후 12 50 09" src="https://user-images.githubusercontent.com/73515587/160266701-6dd02ed4-ee97-4881-ad1d-3e34d89e368f.png">
