### PR TITLE
[FEAT] 게시판 추가, 조회 API

### DIFF
--- a/src/main/java/server/sookdak/api/BoardApi.java
+++ b/src/main/java/server/sookdak/api/BoardApi.java
@@ -1,0 +1,27 @@
+package server.sookdak.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import server.sookdak.dto.req.BoardSaveRequestDto;
+import server.sookdak.dto.res.BoardListResponseDto;
+import server.sookdak.service.BoardService;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/board")
+public class BoardApi {
+    private final BoardService boardService;
+
+    @GetMapping()
+    public List<BoardListResponseDto> findAll(){
+        return boardService.findAllDesc();
+    }
+
+    @PostMapping("/{userId}/save")
+    public Long save(@PathVariable Long userId, @RequestBody BoardSaveRequestDto boardSaveRequestDto){
+        return boardService.SaveBoard(userId, boardSaveRequestDto);
+    }
+}

--- a/src/main/java/server/sookdak/config/SecurityConfig.java
+++ b/src/main/java/server/sookdak/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                 .authorizeRequests()
                 .antMatchers("/api/user/**").permitAll() //인증 없이 접근 허용
+                .antMatchers("/api/board/**").permitAll()
                 .anyRequest().authenticated() //나머지 요청은 모두 인증 필요
 
                 //JwtFilter를 addFilterBefore로 등록했던 JwtSecurityConfig 클래스 적용

--- a/src/main/java/server/sookdak/domain/Board.java
+++ b/src/main/java/server/sookdak/domain/Board.java
@@ -1,0 +1,45 @@
+package server.sookdak.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Board {
+
+    @Id
+    @Column(name="board_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long boardId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_Id")
+    private User user;
+
+    @NotNull(message = "이름을 입력해주세요")
+    @Column(length=20)
+    private String name;
+
+    private String description;
+
+    @Builder
+    public Board(Long boardId, User user, String name, String description){
+        this.boardId = boardId;
+        this.user = user;
+        this.name = name;
+        this.description = description;
+    }
+
+    public void createdByUser(User user){
+        this.user = user;
+    }
+
+
+
+}

--- a/src/main/java/server/sookdak/domain/User.java
+++ b/src/main/java/server/sookdak/domain/User.java
@@ -4,6 +4,8 @@ import com.sun.istack.NotNull;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -26,6 +28,10 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Authority authority;
 
+    @OneToMany(mappedBy = "user")
+    private List<Board> board = new ArrayList<>();
+
+
     public static User createUser(String email, String password, Authority authority) {
         User user = new User();
         user.email = email;
@@ -34,7 +40,10 @@ public class User {
         return user;
     }
 
-    public void setRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
+    public void setRefreshToken(String refreshToken) {this.refreshToken = refreshToken;}
+
+    public void createBoard(Board board){
+        this.board.add(board);
+        board.createdByUser(this);
     }
 }

--- a/src/main/java/server/sookdak/dto/req/BoardSaveRequestDto.java
+++ b/src/main/java/server/sookdak/dto/req/BoardSaveRequestDto.java
@@ -1,0 +1,13 @@
+package server.sookdak.dto.req;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoardSaveRequestDto {
+    private String name;
+    private String description;
+}

--- a/src/main/java/server/sookdak/dto/res/BoardListResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/BoardListResponseDto.java
@@ -1,0 +1,15 @@
+package server.sookdak.dto.res;
+
+import lombok.Getter;
+import server.sookdak.domain.Board;
+
+@Getter
+public class BoardListResponseDto {
+    private String name;
+    private String description;
+
+    public BoardListResponseDto(Board entity){
+        this.name = entity.getName();
+        this.description = entity.getDescription();
+    }
+}

--- a/src/main/java/server/sookdak/repository/BoardRepository.java
+++ b/src/main/java/server/sookdak/repository/BoardRepository.java
@@ -1,0 +1,13 @@
+package server.sookdak.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import server.sookdak.domain.Board;
+
+import java.util.List;
+
+public interface BoardRepository extends JpaRepository<Board,Long> {
+    @Query("SELECT p FROM Board p ORDER BY p.boardId DESC")
+    List<Board> findAllDesc();
+
+}

--- a/src/main/java/server/sookdak/service/BoardService.java
+++ b/src/main/java/server/sookdak/service/BoardService.java
@@ -1,0 +1,42 @@
+package server.sookdak.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.sookdak.domain.Board;
+import server.sookdak.domain.User;
+import server.sookdak.dto.req.BoardSaveRequestDto;
+import server.sookdak.dto.res.BoardListResponseDto;
+import server.sookdak.repository.BoardRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BoardService {
+    private final BoardRepository boardRepository;
+    private final UserService userService;
+
+    @Transactional(readOnly = true)
+    public List<BoardListResponseDto> findAllDesc(){
+        return boardRepository.findAllDesc().stream()
+                .map(BoardListResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+
+    public Long SaveBoard(Long userId, BoardSaveRequestDto boardSaveRequestDto){
+        User user = userService.findById(userId);
+        Board board = Board.builder()
+                .name(boardSaveRequestDto.getName())
+                .description((boardSaveRequestDto.getDescription()))
+                .build();
+        Board savedBoard = boardRepository.save(board);
+        user.createBoard(savedBoard);
+        return savedBoard.getBoardId();
+
+    }
+
+}

--- a/src/main/java/server/sookdak/service/UserService.java
+++ b/src/main/java/server/sookdak/service/UserService.java
@@ -40,6 +40,12 @@ public class UserService {
         return UserResponseDto.toUserResponseDto(userEmail, user.getAuthority());
     }
 
+    public User findById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND));
+    }
+
+
     public TokenDto login(UserRequestDto userRequestDto) {
         if (!(userRequestDto.getEmail().contains("sookmyung.ac.kr") || userRequestDto.getEmail().contains("sm.ac.kr"))) {
             throw new CustomException(ExceptionCode.SOOKMYUNG_ONLY);


### PR DESCRIPTION
## 작업사항
게시판을 추가하고 게시판리스트를 조회할 수 있는 API를 만들었습니다
그런데 도메인에서 게시판 name이 없으면 못 만들도록 했다고 생각했는데 테스트 돌려보니까 만들어져서 ,,이 부분은 다시 수정해볼게요ㅠ
그리구 테스트 돌릴 때 success code랑 fail code랑 데이터 담아서 내보내는 형식으로도 다시 만들어야하는데  이 부분은 유진님께 조언을 구하고 다시 해야합니다 
하면서도 아리송한 부분이 너무 많아서;;; 코드 읽어보시구 피드백 해주세요 

closed #5 
## 테스트
### 게시판 조회
<img width="669" alt="스크린샷 2022-04-04 오전 7 50 54" src="https://user-images.githubusercontent.com/62243967/161453522-23407cc9-9d5e-45b6-8d84-f1c1db5abd3b.png">

###게시판 생성
<img width="659" alt="스크린샷 2022-04-04 오전 7 51 55" src="https://user-images.githubusercontent.com/62243967/161453539-cf461c29-8643-4917-9c1f-9cb81071f03f.png">

