### PR TITLE
[FIX] 게시판 추가 API 수정

### DIFF
--- a/src/main/java/server/sookdak/api/BoardApi.java
+++ b/src/main/java/server/sookdak/api/BoardApi.java
@@ -1,13 +1,20 @@
 package server.sookdak.api;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import server.sookdak.constants.SuccessCode;
 import server.sookdak.dto.req.BoardSaveRequestDto;
 import server.sookdak.dto.res.BoardListResponseDto;
+import server.sookdak.dto.res.BoardResponse;
+import server.sookdak.dto.res.UserResponse;
 import server.sookdak.service.BoardService;
 
+import javax.validation.Valid;
 import java.util.List;
+
+import static server.sookdak.constants.SuccessCode.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -16,12 +23,14 @@ public class BoardApi {
     private final BoardService boardService;
 
     @GetMapping()
-    public List<BoardListResponseDto> findAll(){
+    public List<BoardListResponseDto> findAll() {
         return boardService.findAllDesc();
     }
 
-    @PostMapping("/{userId}/save")
-    public Long save(@PathVariable Long userId, @RequestBody BoardSaveRequestDto boardSaveRequestDto){
-        return boardService.SaveBoard(userId, boardSaveRequestDto);
+    @PostMapping("/save")
+    public ResponseEntity<BoardResponse> save(@Valid @RequestBody BoardSaveRequestDto boardSaveRequestDto) {
+        boardService.saveBoard(boardSaveRequestDto);
+
+        return BoardResponse.newResponse(BOARD_SAVE_SUCCESS);
     }
 }

--- a/src/main/java/server/sookdak/constants/ExceptionCode.java
+++ b/src/main/java/server/sookdak/constants/ExceptionCode.java
@@ -9,6 +9,9 @@ import static org.springframework.http.HttpStatus.*;
 @Getter
 @AllArgsConstructor
 public enum ExceptionCode {
+    /* 400 - 잘못된 요청 */
+
+    /* 401 - 인증 실패 */
     // token 관련
     WRONG_TYPE_TOKEN(UNAUTHORIZED, "잘못된 JWT 서명을 가진 토큰입니다."),
     EXPIRED_TOKEN(UNAUTHORIZED, "만료된 JWT 토큰입니다."),
@@ -23,7 +26,10 @@ public enum ExceptionCode {
     SOOKMYUNG_ONLY(FORBIDDEN, "숙명 계정으로 로그인해야 합니다."),
 
     /* 404 - 찾을 수 없는 리소스 */
-    MEMBER_EMAIL_NOT_FOUND(NOT_FOUND, "가입되지 않은 이메일입니다.");
+    MEMBER_EMAIL_NOT_FOUND(NOT_FOUND, "가입되지 않은 이메일입니다."),
+
+    /* 409 - 중복된 리소스 */
+    DUPLICATE_BOARD_NAME(CONFLICT, "이미 해당 이름을 가진 게시판이 있습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -12,7 +12,10 @@ public enum SuccessCode {
     SIGNUP_SUCCESS(OK, "회원가입을 완료했습니다."),
     LOGIN_SUCCESS(OK, "로그인에 성공했습니다."),
     USER_INFO_SUCCESS(OK, "유저 조회에 성공했습니다."),
-    REISSUE_SUCCESS(OK, "토큰 재발급에 성공했습니다.");
+    REISSUE_SUCCESS(OK, "토큰 재발급에 성공했습니다."),
+
+    BOARD_SAVE_SUCCESS(OK, "게시판 추가에 성공했습니다."),
+    BOARD_READ_SUCCESS(OK, "게시판 조회에 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/server/sookdak/domain/Board.java
+++ b/src/main/java/server/sookdak/domain/Board.java
@@ -14,32 +14,24 @@ import javax.validation.constraints.NotNull;
 public class Board {
 
     @Id
-    @Column(name="board_id")
+    @Column(name = "board_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long boardId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="user_Id")
+    @JoinColumn(name = "user_Id")
     private User user;
 
     @NotNull(message = "이름을 입력해주세요")
-    @Column(length=20)
+    @Column(length = 20)
     private String name;
 
     private String description;
 
-    @Builder
-    public Board(Long boardId, User user, String name, String description){
-        this.boardId = boardId;
-        this.user = user;
-        this.name = name;
-        this.description = description;
+    public static Board createBoard(String name, String description) {
+        Board board = new Board();
+        board.name = name;
+        board.description = description;
+        return board;
     }
-
-    public void createdByUser(User user){
-        this.user = user;
-    }
-
-
-
 }

--- a/src/main/java/server/sookdak/domain/User.java
+++ b/src/main/java/server/sookdak/domain/User.java
@@ -4,8 +4,6 @@ import com.sun.istack.NotNull;
 import lombok.*;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Entity
@@ -28,10 +26,6 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Authority authority;
 
-    @OneToMany(mappedBy = "user")
-    private List<Board> board = new ArrayList<>();
-
-
     public static User createUser(String email, String password, Authority authority) {
         User user = new User();
         user.email = email;
@@ -40,10 +34,7 @@ public class User {
         return user;
     }
 
-    public void setRefreshToken(String refreshToken) {this.refreshToken = refreshToken;}
-
-    public void createBoard(Board board){
-        this.board.add(board);
-        board.createdByUser(this);
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/server/sookdak/dto/req/BoardSaveRequestDto.java
+++ b/src/main/java/server/sookdak/dto/req/BoardSaveRequestDto.java
@@ -4,10 +4,17 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BoardSaveRequestDto {
+    @NotBlank(message = "게시판 이름이 없습니다.")
     private String name;
+
     private String description;
 }

--- a/src/main/java/server/sookdak/dto/res/BoardResponse.java
+++ b/src/main/java/server/sookdak/dto/res/BoardResponse.java
@@ -1,0 +1,20 @@
+package server.sookdak.dto.res;
+
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+
+public class BoardResponse extends BaseResponse {
+
+    private BoardResponse(Boolean success, String msg) {
+        super(success, msg);
+    }
+
+    public static BoardResponse of(Boolean success, String msg) {
+        return new BoardResponse(success, msg);
+    }
+
+    public static ResponseEntity<BoardResponse> newResponse(SuccessCode code) {
+        return new ResponseEntity(BoardResponse.of(true, code.getMessage()), code.getStatus());
+    }
+}

--- a/src/main/java/server/sookdak/exception/RestExceptionHandler.java
+++ b/src/main/java/server/sookdak/exception/RestExceptionHandler.java
@@ -1,7 +1,9 @@
 package server.sookdak.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import server.sookdak.dto.BaseResponse;
@@ -17,4 +19,12 @@ public class RestExceptionHandler {
         log.warn(String.format("[%s Error] : %s %s", e.getExceptionCode().getStatus(), request.getMethod(), request.getRequestURI()));
         return BaseResponse.toCustomErrorResponse(e.getExceptionCode());
     }
+
+    // @RequestBody valid 에러
+    @ExceptionHandler(value = { MethodArgumentNotValidException.class })
+    protected ResponseEntity<BaseResponse> handleMethodArgNotValidException(MethodArgumentNotValidException e, HttpServletRequest request) {
+        log.warn(String.format("[400 Error] : %s %s", request.getMethod(), request.getRequestURI()));
+        return BaseResponse.toBasicErrorResponse(HttpStatus.BAD_REQUEST, e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
+    }
+
 }

--- a/src/main/java/server/sookdak/repository/BoardRepository.java
+++ b/src/main/java/server/sookdak/repository/BoardRepository.java
@@ -10,4 +10,5 @@ public interface BoardRepository extends JpaRepository<Board,Long> {
     @Query("SELECT p FROM Board p ORDER BY p.boardId DESC")
     List<Board> findAllDesc();
 
+    boolean existsByName(String name);
 }

--- a/src/main/java/server/sookdak/service/UserService.java
+++ b/src/main/java/server/sookdak/service/UserService.java
@@ -40,12 +40,6 @@ public class UserService {
         return UserResponseDto.toUserResponseDto(userEmail, user.getAuthority());
     }
 
-    public User findById(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND));
-    }
-
-
     public TokenDto login(UserRequestDto userRequestDto) {
         if (!(userRequestDto.getEmail().contains("sookmyung.ac.kr") || userRequestDto.getEmail().contains("sm.ac.kr"))) {
             throw new CustomException(ExceptionCode.SOOKMYUNG_ONLY);


### PR DESCRIPTION
## 작업사항
<!-- 이 밑에 작업사항 설명이랑, 리뷰어가 어떤 부분 집중하면 좋을지 쓰면 됩니다 -->
### 1. userId 받지 않고 jwt에서 제공하는 유저 찾는 로직 사용하기
uri에서도 pathvariable로 userId 받는 부분 뺐고, boardService에서 내가 말한 코드로 바꿔놓은 거 볼 수 있을거야
내가 boardService에 주석으로 설명 써놨어! 천천히 봐바
    
### 2. User 도메인에서 board list 있는 부분 삭제
유저 별로 어떤 게시판 생성했는지 확인하는 거는 도메인에 list 안넣고 그냥 쿼리로 조회하는게 좋을 것 같아서 이 부분은 뺐어!!
    
### 3. 게시판 이름 빈 문자열일 때 fail
BoardSaveRequestDto에 있는 name에다가 @NotBlank 붙여놓고 @Valid 사용해서 검증하는 걸로 해놨거든! 이러면 @ReqeustBody로 요청 들어왔을 때 자동으로 유효성 검증을 해준대 그래서 빈 문자열 보내면 예외처리 되게 해놨어
찾아보니까 3개 차이가 이렇대 그래서 NotBlank로 해뒀어!
```
@NotNull // null 불가능
@NotEmpty // null, 빈 문자열(스페이스 포함X) 불가
@NotBlank // null, 빈 문자열, 스페이스만 포함한 문자열 불가
```

### 4. 게시판 이름이 중복될 때 fail
생각해보니까 게시판 이름 똑같을 때 중복 안되게 해야 할 것 같아서... 추가했슴다
constants/exceptioncode에 에러코드 상수 작성해놨거든 이거 확인해봐!! 너도 담에 여기다가 상수 작성한 후에 throw new CustomException(상수); 이런 식으로 사용하면 에러 처리 바로 될거야

> 모르는 거 있음 바로 물어봐!!!

## 테스트
### 게시판 추가 SUCCESS
<img width="747" alt="스크린샷 2022-04-04 오후 3 32 32" src="https://user-images.githubusercontent.com/73515587/161487629-9d5b9974-5bae-45d2-bd6e-25cd04234f20.png">

### 게시판 추가 FAIL - 게시판 이름 빈 문자열일 때
<img width="747" alt="스크린샷 2022-04-04 오후 3 12 12" src="https://user-images.githubusercontent.com/73515587/161487533-c56ad5d8-8802-4572-81f5-26aad3cf8f54.png">
<img width="747" alt="스크린샷 2022-04-04 오후 3 24 40" src="https://user-images.githubusercontent.com/73515587/161487543-76c578c7-6ab5-480c-8254-38dade6eb0ee.png">

### 게시판 추가 FAIL - 게시판 이름 중복
<img width="747" alt="스크린샷 2022-04-04 오후 3 12 03" src="https://user-images.githubusercontent.com/73515587/161487611-98c7a586-83e6-4a5e-8832-5e8f9f25c240.png">

### 게시판 추가 FAIL - 헤더에 토큰 보내지 않았을 때
<img width="747" alt="스크린샷 2022-04-04 오후 3 27 29" src="https://user-images.githubusercontent.com/73515587/161487583-889d00ee-cff5-4786-8fc2-eb349715e2eb.png">
