### PR TITLE
[FIX] 게시판 조회 API 수정

### DIFF
--- a/src/main/java/server/sookdak/api/BoardApi.java
+++ b/src/main/java/server/sookdak/api/BoardApi.java
@@ -6,6 +6,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import server.sookdak.constants.SuccessCode;
 import server.sookdak.dto.req.BoardSaveRequestDto;
+import server.sookdak.dto.res.BoardListResponse;
 import server.sookdak.dto.res.BoardListResponseDto;
 import server.sookdak.dto.res.BoardResponse;
 import server.sookdak.dto.res.UserResponse;
@@ -23,8 +24,10 @@ public class BoardApi {
     private final BoardService boardService;
 
     @GetMapping()
-    public List<BoardListResponseDto> findAll() {
-        return boardService.findAllDesc();
+    public ResponseEntity<BoardListResponse> findAll() {
+        BoardListResponseDto responseDto = boardService.findAllDesc();
+
+        return BoardListResponse.newResponse(BOARD_READ_SUCCESS, responseDto);
     }
 
     @PostMapping("/save")

--- a/src/main/java/server/sookdak/dto/BaseResponse.java
+++ b/src/main/java/server/sookdak/dto/BaseResponse.java
@@ -13,12 +13,12 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class BaseResponse {
 
-    private Boolean succcess;
+    private Boolean success;
     private String message;
     private LocalDateTime timestamp = LocalDateTime.now();
 
     public BaseResponse(Boolean success, String message) {
-        this.succcess = success;
+        this.success = success;
         this.message = message;
     }
 

--- a/src/main/java/server/sookdak/dto/res/BoardListResponse.java
+++ b/src/main/java/server/sookdak/dto/res/BoardListResponse.java
@@ -1,0 +1,27 @@
+package server.sookdak.dto.res;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+
+@Getter
+@NoArgsConstructor
+public class BoardListResponse extends BaseResponse {
+    BoardListResponseDto data;
+
+    private BoardListResponse(Boolean success, String msg, BoardListResponseDto data) {
+        super(success, msg);
+        this.data = data;
+    }
+
+    public static BoardListResponse of(Boolean success, String msg, BoardListResponseDto data) {
+        return new BoardListResponse(success, msg, data);
+    }
+
+    public static ResponseEntity<BoardListResponse> newResponse(SuccessCode code, BoardListResponseDto data) {
+        BoardListResponse response = BoardListResponse.of(true, code.getMessage(), data);
+        return new ResponseEntity(response, code.getStatus());
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/BoardListResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/BoardListResponseDto.java
@@ -1,15 +1,32 @@
 package server.sookdak.dto.res;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import server.sookdak.domain.Board;
 
-@Getter
-public class BoardListResponseDto {
-    private String name;
-    private String description;
+import java.util.List;
 
-    public BoardListResponseDto(Board entity){
-        this.name = entity.getName();
-        this.description = entity.getDescription();
+@Getter
+@NoArgsConstructor
+public class BoardListResponseDto {
+    private List<BoardList> boards;
+
+    private BoardListResponseDto(List<BoardList> boards) {
+        this.boards = boards;
+    }
+
+    public static BoardListResponseDto of(List<BoardList> boards) {
+        return new BoardListResponseDto(boards);
+    }
+
+    @Getter
+    public static class BoardList {
+        private String name;
+        private String description;
+
+        public BoardList(Board entity){
+            this.name = entity.getName();
+            this.description = entity.getDescription();
+        }
     }
 }

--- a/src/main/java/server/sookdak/service/BoardService.java
+++ b/src/main/java/server/sookdak/service/BoardService.java
@@ -7,6 +7,7 @@ import server.sookdak.domain.Board;
 import server.sookdak.domain.User;
 import server.sookdak.dto.req.BoardSaveRequestDto;
 import server.sookdak.dto.res.BoardListResponseDto;
+import server.sookdak.dto.res.BoardListResponseDto.BoardList;
 import server.sookdak.exception.CustomException;
 import server.sookdak.repository.BoardRepository;
 import server.sookdak.repository.UserRepository;
@@ -25,10 +26,11 @@ public class BoardService {
     private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
-    public List<BoardListResponseDto> findAllDesc() {
-        return boardRepository.findAllDesc().stream()
-                .map(BoardListResponseDto::new)
+    public BoardListResponseDto findAllDesc() {
+        List<BoardList> boards = boardRepository.findAllDesc().stream()
+                .map(BoardList::new)
                 .collect(Collectors.toList());
+        return BoardListResponseDto.of(boards);
     }
 
     public void saveBoard(BoardSaveRequestDto boardSaveRequestDto) {


### PR DESCRIPTION
## 작업사항
<!-- 이 밑에 작업사항 설명이랑, 리뷰어가 어떤 부분 집중하면 좋을지 쓰면 됩니다 -->
일단 Api에서 ResponseEntity로 응답해주는게 좋아서 그렇게 다 바꿨어!
보통 데이터를 보내줄 때는 "data" 변수 안에다가 담아주는게 좋은데 배열을 담아야 할 때는 data 안에서 한 번 더 묶어주는 게 좋거든
그래서 지금 BoardListResponse를 추가했고 너가 원래 만들어놨던 BoardListResponseDto를 조금 수정했어
내가 노션에 API 명세서도 수정해놨으니까 함 봐봐!
그리고 인텔리제이에서 풀 받은 후에 커맨드+마우스로 클릭하면 해당 클래스로 이동하니까 그렇게 타고타고 들어가면서 코드 이해하려구 해봐바

> 어렵지........ 모르는 거 있음 꼭.... 말해주기
closed #9 

## 테스트
### 게시판 조회 SUCCESS
<img width="747" alt="스크린샷 2022-04-04 오후 5 09 50" src="https://user-images.githubusercontent.com/73515587/161502635-8bd9e970-8863-4acb-bae9-62fa401d73a6.png">

