### PR TITLE
[FIX] 로그인/회원가입 API 수정

### DIFF
--- a/src/main/java/server/sookdak/api/UserApi.java
+++ b/src/main/java/server/sookdak/api/UserApi.java
@@ -31,9 +31,6 @@ public class UserApi {
     @PostMapping("/login")
     public ResponseEntity<TokenResponse> login(@Valid @RequestBody UserRequestDto userRequestDto) {
         TokenDto tokenDto = userService.login(userRequestDto);
-        if (tokenDto == null) {
-            return TokenResponse.toResponse(SIGNUP_SUCCESS, null);
-        }
 
         return TokenResponse.toResponse(LOGIN_SUCCESS, tokenDto);
     }

--- a/src/main/java/server/sookdak/service/UserService.java
+++ b/src/main/java/server/sookdak/service/UserService.java
@@ -48,7 +48,6 @@ public class UserService {
             // signup
             User user = userRequestDto.toUser(passwordEncoder, key);
             userRepository.save(user);
-            return null;
         }
 
         //1. AuthenticationToken 생성


### PR DESCRIPTION
## 작업사항
<!-- 이 밑에 작업사항 설명이랑, 리뷰어가 어떤 부분 집중하면 좋을지 쓰면 됩니다 -->
회원가입이 어차피 db에 회원 정보 저장만 하면 되는거라서 회원가입을 따로 구분하지 않아도 될 것 같습니다~~~
그래서 회원가입 시에도 그냥 로그인 성공했다고 토큰 반환되게 바꿨어용
closed #17 

## 테스트
### 로그인 성공 SUCCESS
<img width="746" alt="스크린샷 2022-04-05 오후 8 02 00" src="https://user-images.githubusercontent.com/73515587/161740694-fb1f83b3-7589-40a8-b564-3bc85109a14b.png">

<!-- 이 밑에 테스트 결과 사진 첨부! 이런 식으로 밑에다가 쭉 써주면 됩니다 -->
