### PR TITLE
[FEAT] 게시글 저장 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.3.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/server/sookdak/api/PostApi.java
+++ b/src/main/java/server/sookdak/api/PostApi.java
@@ -1,0 +1,51 @@
+package server.sookdak.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import server.sookdak.constants.ExceptionCode;
+import server.sookdak.dto.req.PostSaveRequestDto;
+import server.sookdak.dto.res.PostResponse;
+import server.sookdak.exception.CustomException;
+import server.sookdak.service.PostService;
+import server.sookdak.util.S3Util;
+
+import javax.validation.Valid;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static server.sookdak.constants.SuccessCode.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/post")
+public class PostApi {
+
+    private final PostService postService;
+    private final S3Util s3Util;
+
+    @PostMapping("/{boardId}/save")
+    public ResponseEntity<PostResponse> savePost(@PathVariable Long boardId,
+                                                 @Valid @ModelAttribute PostSaveRequestDto postSaveRequestDto) throws IOException {
+
+        List<String> imageURLs = new ArrayList<>();
+        if (postSaveRequestDto.getImages().size() > 0) {
+            imageURLs = postSaveRequestDto.getImages().stream()
+                    .map(image -> {
+                        try {
+                            return s3Util.postUpload(image);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e.toString());
+                        }
+                    })
+                    .collect(Collectors.toList());
+        }
+
+        postService.savePost(postSaveRequestDto, boardId, imageURLs);
+
+        return PostResponse.newResponse(POST_SAVE_SUCCESS);
+    }
+}

--- a/src/main/java/server/sookdak/config/AmazonS3Config.java
+++ b/src/main/java/server/sookdak/config/AmazonS3Config.java
@@ -1,0 +1,30 @@
+package server.sookdak.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AmazonS3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .build();
+    }
+}

--- a/src/main/java/server/sookdak/config/SecurityConfig.java
+++ b/src/main/java/server/sookdak/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/api/user/**").permitAll() //인증 없이 접근 허용
                 .antMatchers("/api/board/**").permitAll()
+                .antMatchers("/api/post/**").permitAll()
                 .anyRequest().authenticated() //나머지 요청은 모두 인증 필요
 
                 //JwtFilter를 addFilterBefore로 등록했던 JwtSecurityConfig 클래스 적용

--- a/src/main/java/server/sookdak/constants/ExceptionCode.java
+++ b/src/main/java/server/sookdak/constants/ExceptionCode.java
@@ -24,9 +24,11 @@ public enum ExceptionCode {
     /* 403 - 허용되지 않은 접근 */,
     FORBIDDEN_ACCESS(FORBIDDEN, "허용되지 않은 접근입니다."),
     SOOKMYUNG_ONLY(FORBIDDEN, "숙명 계정으로 로그인해야 합니다."),
+    IMAGE_NUM_EXCESS(FORBIDDEN, "이미지 개수가 10개를 초과했습니다."),
 
     /* 404 - 찾을 수 없는 리소스 */
     MEMBER_EMAIL_NOT_FOUND(NOT_FOUND, "가입되지 않은 이메일입니다."),
+    BOARD_NOT_FOUND(NOT_FOUND, "게시판을 찾을 수 없습니다."),
 
     /* 409 - 중복된 리소스 */
     DUPLICATE_BOARD_NAME(CONFLICT, "이미 해당 이름을 가진 게시판이 있습니다.");

--- a/src/main/java/server/sookdak/constants/ExceptionCode.java
+++ b/src/main/java/server/sookdak/constants/ExceptionCode.java
@@ -24,7 +24,6 @@ public enum ExceptionCode {
     /* 403 - 허용되지 않은 접근 */,
     FORBIDDEN_ACCESS(FORBIDDEN, "허용되지 않은 접근입니다."),
     SOOKMYUNG_ONLY(FORBIDDEN, "숙명 계정으로 로그인해야 합니다."),
-    IMAGE_NUM_EXCESS(FORBIDDEN, "이미지 개수가 10개를 초과했습니다."),
 
     /* 404 - 찾을 수 없는 리소스 */
     MEMBER_EMAIL_NOT_FOUND(NOT_FOUND, "가입되지 않은 이메일입니다."),

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -15,7 +15,9 @@ public enum SuccessCode {
     REISSUE_SUCCESS(OK, "토큰 재발급에 성공했습니다."),
 
     BOARD_SAVE_SUCCESS(OK, "게시판 추가에 성공했습니다."),
-    BOARD_READ_SUCCESS(OK, "게시판 조회에 성공했습니다.");
+    BOARD_READ_SUCCESS(OK, "게시판 조회에 성공했습니다."),
+
+    POST_SAVE_SUCCESS(OK, "게시글 저장에 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/server/sookdak/domain/Post.java
+++ b/src/main/java/server/sookdak/domain/Post.java
@@ -1,0 +1,43 @@
+package server.sookdak.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post {
+
+    @Id
+    @Column(name = "post_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long postId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    @Column(length = 2000)
+    private String content;
+
+    private String createdAt;
+
+    private Long liked;
+
+    public static Post createPost(User user, Board board, String content, String createdAt) {
+        Post post = new Post();
+        post.user = user;
+        post.board = board;
+        post.content = content;
+        post.createdAt = createdAt;
+        post.liked = 0L;
+        return post;
+    }
+}

--- a/src/main/java/server/sookdak/domain/PostImage.java
+++ b/src/main/java/server/sookdak/domain/PostImage.java
@@ -1,0 +1,30 @@
+package server.sookdak.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostImage {
+    @Id
+    @Column(name = "post_image_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long postImageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    private String url;
+
+    public static PostImage createPostImage(Post post, String url) {
+        PostImage postImage = new PostImage();
+        postImage.post = post;
+        postImage.url = url;
+        return postImage;
+    }
+}

--- a/src/main/java/server/sookdak/dto/req/PostSaveRequestDto.java
+++ b/src/main/java/server/sookdak/dto/req/PostSaveRequestDto.java
@@ -5,6 +5,7 @@ import org.hibernate.validator.constraints.Length;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,6 +16,7 @@ public class PostSaveRequestDto {
     @Length(max = 2000, message = "글자수가 2000자를 초과했습니다.")
     private String content;
 
+    @Size(max = 10, message = "이미지 개수가 10개를 초과했습니다.")
     private List<MultipartFile> images = new ArrayList<>();
 
 }

--- a/src/main/java/server/sookdak/dto/req/PostSaveRequestDto.java
+++ b/src/main/java/server/sookdak/dto/req/PostSaveRequestDto.java
@@ -1,0 +1,20 @@
+package server.sookdak.dto.req;
+
+import lombok.Data;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.constraints.NotBlank;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class PostSaveRequestDto {
+
+    @NotBlank(message = "게시글 내용이 없습니다.")
+    @Length(max = 2000, message = "글자수가 2000자를 초과했습니다.")
+    private String content;
+
+    private List<MultipartFile> images = new ArrayList<>();
+
+}

--- a/src/main/java/server/sookdak/dto/res/PostResponse.java
+++ b/src/main/java/server/sookdak/dto/res/PostResponse.java
@@ -1,0 +1,20 @@
+package server.sookdak.dto.res;
+
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+
+public class PostResponse extends BaseResponse {
+
+    private PostResponse(Boolean success, String message) {
+        super(success, message);
+    }
+
+    public static PostResponse of(Boolean success, String message) {
+        return new PostResponse(success, message);
+    }
+
+    public static ResponseEntity<PostResponse> newResponse(SuccessCode code) {
+        return new ResponseEntity(PostResponse.of(true, code.getMessage()), code.getStatus());
+    }
+}

--- a/src/main/java/server/sookdak/exception/RestExceptionHandler.java
+++ b/src/main/java/server/sookdak/exception/RestExceptionHandler.java
@@ -3,6 +3,7 @@ package server.sookdak.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -27,4 +28,10 @@ public class RestExceptionHandler {
         return BaseResponse.toBasicErrorResponse(HttpStatus.BAD_REQUEST, e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
     }
 
+    // @ModelAttribute valid 에러
+    @ExceptionHandler(value = { BindException.class })
+    protected ResponseEntity<BaseResponse> handleMethodArgNotValidException(BindException e, HttpServletRequest request) {
+        log.warn(String.format("[400 Error] : %s %s", request.getMethod(), request.getRequestURI()));
+        return BaseResponse.toBasicErrorResponse(HttpStatus.BAD_REQUEST, e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
+    }
 }

--- a/src/main/java/server/sookdak/repository/PostImageRepository.java
+++ b/src/main/java/server/sookdak/repository/PostImageRepository.java
@@ -1,0 +1,7 @@
+package server.sookdak.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.sookdak.domain.PostImage;
+
+public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+}

--- a/src/main/java/server/sookdak/repository/PostRepository.java
+++ b/src/main/java/server/sookdak/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package server.sookdak.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.sookdak.domain.Post;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/server/sookdak/service/PostService.java
+++ b/src/main/java/server/sookdak/service/PostService.java
@@ -1,0 +1,52 @@
+package server.sookdak.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.sookdak.domain.Board;
+import server.sookdak.domain.Post;
+import server.sookdak.domain.PostImage;
+import server.sookdak.domain.User;
+import server.sookdak.dto.req.PostSaveRequestDto;
+import server.sookdak.exception.CustomException;
+import server.sookdak.repository.BoardRepository;
+import server.sookdak.repository.PostImageRepository;
+import server.sookdak.repository.PostRepository;
+import server.sookdak.repository.UserRepository;
+import server.sookdak.util.SecurityUtil;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static server.sookdak.constants.ExceptionCode.BOARD_NOT_FOUND;
+import static server.sookdak.constants.ExceptionCode.USER_NOT_FOUND;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final PostImageRepository postImageRepository;
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+
+    public void savePost(PostSaveRequestDto postSaveRequestDto, Long boardId, List<String> imageURLs) {
+        String userEmail = SecurityUtil.getCurrentUserEmail();
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new CustomException(BOARD_NOT_FOUND));
+
+        Post post = Post.createPost(user, board, postSaveRequestDto.getContent(), LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm")));
+
+        for (String imageURL : imageURLs) {
+            PostImage postImage = PostImage.createPostImage(post, imageURL);
+            postImageRepository.save(postImage);
+        }
+
+        postRepository.save(post);
+    }
+}

--- a/src/main/java/server/sookdak/util/S3Util.java
+++ b/src/main/java/server/sookdak/util/S3Util.java
@@ -1,0 +1,60 @@
+package server.sookdak.util;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class S3Util {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    public String bucket;
+
+    public String upload(MultipartFile file, String path) throws IOException {
+        ObjectMetadata objMeta = new ObjectMetadata();
+
+        byte[] bytes = IOUtils.toByteArray(file.getInputStream());
+        objMeta.setContentLength(bytes.length);
+
+        ByteArrayInputStream byteArrayIs = new ByteArrayInputStream(bytes);
+
+        String fileName = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")).concat(Long.toString(System.nanoTime()));
+
+        amazonS3Client.putObject(new PutObjectRequest(bucket, path + "/" + fileName, byteArrayIs, objMeta)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+
+        String imageURL = amazonS3Client.getUrl(bucket, path + "/" + fileName).toString();
+        return imageURL;
+    }
+
+    public String postUpload(MultipartFile file) throws IOException {
+        return upload(file, "post");
+    }
+
+    public String commentUpload(MultipartFile file, int num) throws IOException {
+        return upload(file, "comment");
+    }
+
+    public void delete(String url) {
+        String key = url.split("https://sookdak.s3.ap-northeast-2.amazonaws.com/")[1];
+        DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucket, key);
+        amazonS3Client.deleteObject(deleteObjectRequest);
+    }
+}


### PR DESCRIPTION
## 작업사항
<!-- 이 밑에 작업사항 설명이랑, 리뷰어가 어떤 부분 집중하면 좋을지 쓰면 됩니다 -->
이미지 저장할 수 있는 AWS S3 버킷 팠고, application.yml도 수정됐는데 수정된 파일은 슬랙에 올려줄게! 이 파일로 바꿔서 돌리면 돼
글자수는 2000자까지, 이미지는 10개까지 올릴 수 있도록 제한해뒀어
AWS cloud 사용 때문에 build.gradle에도 의존성 하나 추가했는데 너가 pull 받고 나서 build 한 번 더 해주면 될 것 같아
db에도 post랑 post_image 테이블 생성된 것도 확인했으
closed #13 

## 테스트
### 게시글 저장 SUCCESS
게시글 저장 test는 포스트맨에서 form-data 클릭해서 이런 식으로 보내주면 가능한
<img width="746" alt="스크린샷 2022-04-06 오후 3 28 51" src="https://user-images.githubusercontent.com/73515587/161910018-da297aa7-2bf0-448f-b1ab-d1e0149b98a4.png">

### 게시글 저장 FAIL - 게시글 내용 없을 때
<img width="746" alt="스크린샷 2022-04-06 오후 3 29 11" src="https://user-images.githubusercontent.com/73515587/161910056-47edeb2e-5299-4442-8994-d64729758c55.png">

### 게시글 저장 FAIL - 글자수 2000자 초과
<img width="746" alt="스크린샷 2022-04-06 오후 3 30 02" src="https://user-images.githubusercontent.com/73515587/161910085-566f4742-ab86-4e78-9c14-90b7aa39324d.png">

### 게시글 저장 FAIL - 이미지수 10개 초과
<img width="746" alt="스크린샷 2022-04-06 오후 3 08 21" src="https://user-images.githubusercontent.com/73515587/161910108-214b2e49-a684-494d-9ff1-ce0c4fb7ccf8.png">

### 게시글 저장 FAIL - 잘못된 게시판 id
<img width="746" alt="스크린샷 2022-04-06 오후 3 30 15" src="https://user-images.githubusercontent.com/73515587/161910137-ea8fe672-6639-4b5f-b382-6ea1e6990114.png">
