### PR TITLE
[FEAT] 게시글 목록 조회 API

### DIFF
--- a/src/main/java/server/sookdak/api/PostApi.java
+++ b/src/main/java/server/sookdak/api/PostApi.java
@@ -3,10 +3,10 @@ package server.sookdak.api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import server.sookdak.constants.ExceptionCode;
 import server.sookdak.dto.req.PostSaveRequestDto;
+import server.sookdak.dto.res.PostListResponse;
+import server.sookdak.dto.res.PostListResponseDto;
 import server.sookdak.dto.res.PostResponse;
-import server.sookdak.exception.CustomException;
 import server.sookdak.service.PostService;
 import server.sookdak.util.S3Util;
 
@@ -47,5 +47,12 @@ public class PostApi {
         postService.savePost(postSaveRequestDto, boardId, imageURLs);
 
         return PostResponse.newResponse(POST_SAVE_SUCCESS);
+    }
+
+    @GetMapping("/{order}/{boardId}")
+    public ResponseEntity<PostListResponse> postList(@PathVariable Long boardId, @PathVariable String order) {
+        PostListResponseDto responseDto = postService.getPostList(boardId, order);
+
+        return PostListResponse.newResponse(POST_LIST_READ_SUCCESS, responseDto);
     }
 }

--- a/src/main/java/server/sookdak/constants/ExceptionCode.java
+++ b/src/main/java/server/sookdak/constants/ExceptionCode.java
@@ -10,6 +10,7 @@ import static org.springframework.http.HttpStatus.*;
 @AllArgsConstructor
 public enum ExceptionCode {
     /* 400 - 잘못된 요청 */
+    WRONG_TYPE_ORDER(BAD_REQUEST, "잘못된 order type 입니다."),
 
     /* 401 - 인증 실패 */
     // token 관련

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -17,7 +17,8 @@ public enum SuccessCode {
     BOARD_SAVE_SUCCESS(OK, "게시판 추가에 성공했습니다."),
     BOARD_READ_SUCCESS(OK, "게시판 조회에 성공했습니다."),
 
-    POST_SAVE_SUCCESS(OK, "게시글 저장에 성공했습니다.");
+    POST_SAVE_SUCCESS(OK, "게시글 저장에 성공했습니다."),
+    POST_LIST_READ_SUCCESS(OK, "게시글 목록 조회에 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/server/sookdak/dto/res/PostListResponse.java
+++ b/src/main/java/server/sookdak/dto/res/PostListResponse.java
@@ -1,0 +1,27 @@
+package server.sookdak.dto.res;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+
+@Getter
+@NoArgsConstructor
+public class PostListResponse extends BaseResponse {
+    PostListResponseDto data;
+
+    private PostListResponse(Boolean success, String message, PostListResponseDto data) {
+        super(success, message);
+        this.data = data;
+    }
+
+    public static PostListResponse of(Boolean success, String message, PostListResponseDto data) {
+        return new PostListResponse(success, message, data);
+    }
+
+    public static ResponseEntity<PostListResponse> newResponse(SuccessCode code, PostListResponseDto data) {
+        PostListResponse response = PostListResponse.of(true, code.getMessage(), data);
+        return new ResponseEntity<>(response, code.getStatus());
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/PostListResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/PostListResponseDto.java
@@ -1,0 +1,38 @@
+package server.sookdak.dto.res;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.sookdak.domain.Post;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PostListResponseDto {
+    private List<PostList> posts;
+
+    private PostListResponseDto(List<PostList> posts) {
+        this.posts = posts;
+    }
+
+    public static PostListResponseDto of(List<PostList> posts) {
+        return new PostListResponseDto(posts);
+    }
+
+    @Getter
+    public static class PostList {
+        private Long postId;
+        private String content;
+        private String createdAt;
+        private Long liked;
+        private boolean image;
+
+        public PostList(Post entity, boolean image) {
+            this.postId = entity.getPostId();
+            this.content = entity.getContent();
+            this.createdAt = entity.getCreatedAt();
+            this.liked = entity.getLiked();
+            this.image = image;
+        }
+    }
+}

--- a/src/main/java/server/sookdak/repository/PostImageRepository.java
+++ b/src/main/java/server/sookdak/repository/PostImageRepository.java
@@ -1,7 +1,10 @@
 package server.sookdak.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import server.sookdak.domain.Post;
 import server.sookdak.domain.PostImage;
 
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+
+    boolean existsByPost(Post post);
 }

--- a/src/main/java/server/sookdak/repository/PostRepository.java
+++ b/src/main/java/server/sookdak/repository/PostRepository.java
@@ -1,7 +1,14 @@
 package server.sookdak.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import server.sookdak.domain.Board;
 import server.sookdak.domain.Post;
 
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    List<Post> findAllByBoardOrderByCreatedAtDesc(Board board);
+
+    List<Post> findAllByBoardOrderByLikedDescCreatedAtDesc(Board board);
 }


### PR DESCRIPTION
## 작업사항
<!-- 이 밑에 작업사항 설명이랑, 리뷰어가 어떤 부분 집중하면 좋을지 쓰면 됩니다 -->
게시판 별 게시글 목록 조회하는 API 만들었습니다
최신순, 공감순 두 타입으로 조회할 수 있게 만들었어요
closed #21 

## 테스트
### SUCCESS - 최신순
<img width="750" alt="스크린샷 2022-04-06 오후 10 28 24" src="https://user-images.githubusercontent.com/73515587/161986885-4b79c6dd-a6c2-434d-b957-02c0ede5d634.png">

### SUCCESS - 공감순
<img width="750" alt="스크린샷 2022-04-06 오후 10 28 32" src="https://user-images.githubusercontent.com/73515587/161986950-d1bdf571-6d4d-440a-b55a-fa4e6bbab052.png">

### FAIL - 잘못된 order type
<img width="750" alt="스크린샷 2022-04-06 오후 10 35 10" src="https://user-images.githubusercontent.com/73515587/161987114-472b3cf3-feca-41b3-8d8a-2beebf62e460.png">

### FAIL - 잘못된 게시판 id
<img width="750" alt="스크린샷 2022-04-06 오후 10 35 35" src="https://user-images.githubusercontent.com/73515587/161987213-2d921402-6180-4768-9134-db30fdf7a752.png">

