### PR TITLE
[FEAT] 게시판 즐겨찾기 API

### DIFF
--- a/src/main/java/server/sookdak/api/StarApi.java
+++ b/src/main/java/server/sookdak/api/StarApi.java
@@ -1,0 +1,32 @@
+package server.sookdak.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.res.StarResponse;
+import server.sookdak.service.StarService;
+
+import static server.sookdak.constants.SuccessCode.STAR_CANCEL_SUCCESS;
+import static server.sookdak.constants.SuccessCode.STAR_SUCCESS;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/star")
+public class StarApi {
+
+    private final StarService starService;
+
+    @PostMapping("/{boardId}")
+    public ResponseEntity<StarResponse> star(@PathVariable Long boardId) {
+        boolean response = starService.clickStar(boardId);
+        if (response) {
+            return StarResponse.newResponse(STAR_SUCCESS);
+        } else {
+            return StarResponse.newResponse(STAR_CANCEL_SUCCESS);
+        }
+    }
+}

--- a/src/main/java/server/sookdak/config/SecurityConfig.java
+++ b/src/main/java/server/sookdak/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/api/user/**").permitAll() //인증 없이 접근 허용
                 .antMatchers("/api/board/**").permitAll()
                 .antMatchers("/api/post/**").permitAll()
+                .antMatchers("/api/star/**").permitAll()
                 .anyRequest().authenticated() //나머지 요청은 모두 인증 필요
 
                 //JwtFilter를 addFilterBefore로 등록했던 JwtSecurityConfig 클래스 적용

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -18,7 +18,10 @@ public enum SuccessCode {
     BOARD_READ_SUCCESS(OK, "게시판 조회에 성공했습니다."),
 
     POST_SAVE_SUCCESS(OK, "게시글 저장에 성공했습니다."),
-    POST_LIST_READ_SUCCESS(OK, "게시글 목록 조회에 성공했습니다.");
+    POST_LIST_READ_SUCCESS(OK, "게시글 목록 조회에 성공했습니다."),
+
+    STAR_SUCCESS(OK, "게시판 즐겨찾기에 성공했습니다."),
+    STAR_CANCEL_SUCCESS(OK, "게시판 즐겨찾기 취소에 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/server/sookdak/domain/Star.java
+++ b/src/main/java/server/sookdak/domain/Star.java
@@ -1,0 +1,34 @@
+package server.sookdak.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Star {
+
+    @EmbeddedId
+    private StarId starId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    @MapsId("userId")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    @MapsId("boardId")
+    private Board board;
+
+    public static Star createStar(User user, Board board) {
+        Star star = new Star();
+        star.starId = new StarId(user.getUserId(), board.getBoardId());
+        star.user = user;
+        star.board = board;
+        return star;
+    }
+}

--- a/src/main/java/server/sookdak/domain/StarId.java
+++ b/src/main/java/server/sookdak/domain/StarId.java
@@ -1,0 +1,21 @@
+package server.sookdak.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StarId implements Serializable {
+    private Long userId;
+    private Long boardId;
+
+    public StarId(Long userId, Long boardId) {
+        this.userId = userId;
+        this.boardId = boardId;
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/StarResponse.java
+++ b/src/main/java/server/sookdak/dto/res/StarResponse.java
@@ -1,0 +1,20 @@
+package server.sookdak.dto.res;
+
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+
+public class StarResponse extends BaseResponse {
+
+    private StarResponse(Boolean success, String message) {
+        super(success, message);
+    }
+
+    public static StarResponse of(Boolean success, String message) {
+        return new StarResponse(success, message);
+    }
+
+    public static ResponseEntity<StarResponse> newResponse(SuccessCode code) {
+        return new ResponseEntity<>(StarResponse.of(true, code.getMessage()), code.getStatus());
+    }
+}

--- a/src/main/java/server/sookdak/repository/StarRepsository.java
+++ b/src/main/java/server/sookdak/repository/StarRepsository.java
@@ -1,0 +1,14 @@
+package server.sookdak.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.sookdak.domain.Board;
+import server.sookdak.domain.Star;
+import server.sookdak.domain.StarId;
+import server.sookdak.domain.User;
+
+import java.util.Optional;
+
+public interface StarRepsository extends JpaRepository<Star, StarId> {
+
+    Optional<Star> findByUserAndBoard(User user, Board board);
+}

--- a/src/main/java/server/sookdak/service/StarService.java
+++ b/src/main/java/server/sookdak/service/StarService.java
@@ -1,0 +1,47 @@
+package server.sookdak.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.sookdak.domain.Board;
+import server.sookdak.domain.Star;
+import server.sookdak.domain.User;
+import server.sookdak.exception.CustomException;
+import server.sookdak.repository.BoardRepository;
+import server.sookdak.repository.StarRepsository;
+import server.sookdak.repository.UserRepository;
+import server.sookdak.util.SecurityUtil;
+
+import java.util.Optional;
+
+import static server.sookdak.constants.ExceptionCode.BOARD_NOT_FOUND;
+import static server.sookdak.constants.ExceptionCode.USER_NOT_FOUND;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class StarService {
+
+    private final StarRepsository starRepsository;
+    private final UserRepository userRepository;
+    private final BoardRepository boardRepository;
+
+    public boolean clickStar(Long boardId) {
+        String userEmail = SecurityUtil.getCurrentUserEmail();
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new CustomException(BOARD_NOT_FOUND));
+
+        Optional<Star> existStar = starRepsository.findByUserAndBoard(user, board);
+        if (existStar.isPresent()) {
+            starRepsository.delete(existStar.get());
+            return false;
+        } else {
+            Star star = Star.createStar(user, board);
+            starRepsository.save(star);
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## 작업사항
<!-- 이 밑에 작업사항 설명이랑, 리뷰어가 어떤 부분 집중하면 좋을지 쓰면 됩니다 -->
star 테이블 만들었구요~~~
요청 보내면 그 유저가 이미 즐겨찾기 했는지 검사하고 했으면 취소, 안했으면 즐겨찾기 하는 플로우로 개발 진행했습니다
closed #15 

## 테스트
### 즐겨찾기 SUCCESS
<img width="750" alt="스크린샷 2022-04-07 오전 10 45 55" src="https://user-images.githubusercontent.com/73515587/162104292-357627be-f7f2-4109-b9e5-f4e277993137.png">

### 즐겨찾기 취소 SUCCESS
<img width="750" alt="스크린샷 2022-04-07 오전 10 45 58" src="https://user-images.githubusercontent.com/73515587/162104302-22730deb-0cc4-4562-ad67-cd3413241f74.png">

### FAIL - 잘못된 게시판 id
<img width="750" alt="스크린샷 2022-04-07 오전 10 45 47" src="https://user-images.githubusercontent.com/73515587/162104321-44e82ca6-dbf8-4ce0-b114-60ee7981f3c3.png">

