### PR TITLE
[FEAT] 즐겨찾기한 게시판 조회 API

### DIFF
--- a/src/main/java/server/sookdak/api/StarApi.java
+++ b/src/main/java/server/sookdak/api/StarApi.java
@@ -2,16 +2,14 @@ package server.sookdak.api;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.res.StarListResponse;
+import server.sookdak.dto.res.StarListResponseDto;
 import server.sookdak.dto.res.StarResponse;
 import server.sookdak.service.StarService;
 
-import static server.sookdak.constants.SuccessCode.STAR_CANCEL_SUCCESS;
-import static server.sookdak.constants.SuccessCode.STAR_SUCCESS;
+import static server.sookdak.constants.SuccessCode.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -28,5 +26,12 @@ public class StarApi {
         } else {
             return StarResponse.newResponse(STAR_CANCEL_SUCCESS);
         }
+    }
+
+    @GetMapping()
+    public ResponseEntity<StarListResponse> starList() {
+        StarListResponseDto responseDto = starService.getStarList();
+
+        return StarListResponse.newResponse(STAR_INFO_SUCCESS, responseDto);
     }
 }

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -21,7 +21,8 @@ public enum SuccessCode {
     POST_LIST_READ_SUCCESS(OK, "게시글 목록 조회에 성공했습니다."),
 
     STAR_SUCCESS(OK, "게시판 즐겨찾기에 성공했습니다."),
-    STAR_CANCEL_SUCCESS(OK, "게시판 즐겨찾기 취소에 성공했습니다.");
+    STAR_CANCEL_SUCCESS(OK, "게시판 즐겨찾기 취소에 성공했습니다."),
+    STAR_INFO_SUCCESS(OK, "게시판 즐겨찾기 조회에 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/server/sookdak/domain/Star.java
+++ b/src/main/java/server/sookdak/domain/Star.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -24,11 +25,14 @@ public class Star {
     @MapsId("boardId")
     private Board board;
 
+    private LocalDateTime createdAt;
+
     public static Star createStar(User user, Board board) {
         Star star = new Star();
         star.starId = new StarId(user.getUserId(), board.getBoardId());
         star.user = user;
         star.board = board;
+        star.createdAt = LocalDateTime.now();
         return star;
     }
 }

--- a/src/main/java/server/sookdak/dto/res/StarListResponse.java
+++ b/src/main/java/server/sookdak/dto/res/StarListResponse.java
@@ -1,0 +1,27 @@
+package server.sookdak.dto.res;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+
+@Getter
+@NoArgsConstructor
+public class StarListResponse extends BaseResponse {
+    StarListResponseDto data;
+
+    private StarListResponse(Boolean success, String message, StarListResponseDto data) {
+        super(success, message);
+        this.data = data;
+    }
+
+    public static StarListResponse of(Boolean success, String message, StarListResponseDto data) {
+        return new StarListResponse(success, message, data);
+    }
+
+    public static ResponseEntity<StarListResponse> newResponse(SuccessCode code, StarListResponseDto data) {
+        StarListResponse response = StarListResponse.of(true, code.getMessage(), data);
+        return new ResponseEntity<>(response, code.getStatus());
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/StarListResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/StarListResponseDto.java
@@ -1,0 +1,34 @@
+package server.sookdak.dto.res;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.sookdak.domain.Star;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class StarListResponseDto {
+    private List<StarList> stars;
+
+    private StarListResponseDto(List<StarList> stars) {
+        this.stars = stars;
+    }
+
+    public static StarListResponseDto of(List<StarList> stars) {
+        return new StarListResponseDto(stars);
+    }
+
+    @Getter
+    public static class StarList {
+        private Long boardId;
+        private String name;
+        private String description;
+
+        public StarList(Star star) {
+            this.boardId = star.getBoard().getBoardId();
+            this.name = star.getBoard().getName();
+            this.description = star.getBoard().getDescription();
+        }
+    }
+}

--- a/src/main/java/server/sookdak/repository/StarRepsository.java
+++ b/src/main/java/server/sookdak/repository/StarRepsository.java
@@ -6,9 +6,12 @@ import server.sookdak.domain.Star;
 import server.sookdak.domain.StarId;
 import server.sookdak.domain.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface StarRepsository extends JpaRepository<Star, StarId> {
 
     Optional<Star> findByUserAndBoard(User user, Board board);
+
+    List<Star> findAllByUserOrderByCreatedAtAsc(User user);
 }

--- a/src/main/java/server/sookdak/service/StarService.java
+++ b/src/main/java/server/sookdak/service/StarService.java
@@ -6,16 +6,20 @@ import org.springframework.transaction.annotation.Transactional;
 import server.sookdak.domain.Board;
 import server.sookdak.domain.Star;
 import server.sookdak.domain.User;
+import server.sookdak.dto.res.StarListResponseDto;
 import server.sookdak.exception.CustomException;
 import server.sookdak.repository.BoardRepository;
 import server.sookdak.repository.StarRepsository;
 import server.sookdak.repository.UserRepository;
 import server.sookdak.util.SecurityUtil;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static server.sookdak.constants.ExceptionCode.BOARD_NOT_FOUND;
 import static server.sookdak.constants.ExceptionCode.USER_NOT_FOUND;
+import static server.sookdak.dto.res.StarListResponseDto.*;
 
 @Service
 @Transactional
@@ -43,5 +47,17 @@ public class StarService {
             starRepsository.save(star);
             return true;
         }
+    }
+
+    public StarListResponseDto getStarList() {
+        String userEmail = SecurityUtil.getCurrentUserEmail();
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        List<StarList> stars = starRepsository.findAllByUserOrderByCreatedAtAsc(user).stream()
+                .map(StarList::new)
+                .collect(Collectors.toList());
+
+        return StarListResponseDto.of(stars);
     }
 }


### PR DESCRIPTION
## 작업사항
<!-- 이 밑에 작업사항 설명이랑, 리뷰어가 어떤 부분 집중하면 좋을지 쓰면 됩니다 -->
유저가 즐겨찾기한 게시판 조회하는 API 만들었습니다
변경사항은!!!! star 테이블에 언제 즐겨찾기 추가했는지 생성일자 저장하는 필드 추가했습니다
그래서 조회할 때 최근에 즐겨찾기한 게시판이 배열 뒤로 오도록 만들었습니다~~~
closed #26 

## 테스트
### 즐겨찾기 조회 SUCCESS
<img width="750" alt="스크린샷 2022-04-07 오전 11 24 36" src="https://user-images.githubusercontent.com/73515587/162108174-b71f308c-91ac-4974-8d42-cbb08140a3f5.png">

