### PR TITLE
[FEAT] 게시판 삭제 API

### DIFF
--- a/src/main/java/server/sookdak/api/BoardApi.java
+++ b/src/main/java/server/sookdak/api/BoardApi.java
@@ -32,4 +32,10 @@ public class BoardApi {
         BoardResponseDto responseDto = boardService.saveBoard(boardSaveRequestDto);
         return BoardResponse.newResponse(BOARD_SAVE_SUCCESS,responseDto);
     }
+
+    @DeleteMapping("/{BoardId}")
+    public ResponseEntity<BoardResponse> delete(@PathVariable Long BoardId){
+        BoardResponseDto responseDto = boardService.delete(BoardId);
+        return BoardResponse.newResponse(BOARD_DELETE_SUCCESS,responseDto);
+    }
 }

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -16,6 +16,7 @@ public enum SuccessCode {
 
     BOARD_SAVE_SUCCESS(OK, "게시판 추가에 성공했습니다."),
     BOARD_READ_SUCCESS(OK, "게시판 조회에 성공했습니다."),
+    BOARD_DELETE_SUCCESS(OK, "게시판 삭제에 성공했습니다."),
 
     POST_SAVE_SUCCESS(OK, "게시글 저장에 성공했습니다."),
     POST_LIST_READ_SUCCESS(OK, "게시글 목록 조회에 성공했습니다.");

--- a/src/main/java/server/sookdak/service/BoardService.java
+++ b/src/main/java/server/sookdak/service/BoardService.java
@@ -53,4 +53,12 @@ public class BoardService {
         return BoardResponseDto.of(board);
     }
 
-}
+    public BoardResponseDto delete(Long BoardId) {
+        Board board = boardRepository.findById(BoardId)
+                .orElseThrow(() -> new CustomException(BOARD_NOT_FOUND));
+        boardRepository.delete(board);
+        return BoardResponseDto.of(board);
+    }
+    }
+
+


### PR DESCRIPTION
## 작업사항
게시판 삭제하는 api 만들었습니다~
closed #24

## 테스트
### 게시판 삭제 API

### 성공
<img width="848" alt="스크린샷 2022-04-07 오전 11 21 44" src="https://user-images.githubusercontent.com/62243967/162108472-cfa3634f-1fcc-4757-9ef0-2392c2465578.png">

### 존재하지 않는 게시판을 삭제하려고 시도했을 때
<img width="848" alt="스크린샷 2022-04-07 오전 11 23 36" src="https://user-images.githubusercontent.com/62243967/162108507-de68d0e5-6c68-4eee-959a-da8fa6a4dc44.png">
