### PR TITLE
[FEAT] 게시글 공감 API

### DIFF
--- a/src/main/java/server/sookdak/api/PostApi.java
+++ b/src/main/java/server/sookdak/api/PostApi.java
@@ -55,4 +55,15 @@ public class PostApi {
 
         return PostListResponse.newResponse(POST_LIST_READ_SUCCESS, responseDto);
     }
+
+    @PostMapping("/{postId}/like")
+    public ResponseEntity<PostResponse> postLike(@PathVariable Long postId) {
+        boolean response = postService.clickPostLike(postId);
+        if (response) {
+            return PostResponse.newResponse(LIKE_SUCCESS);
+        } else {
+            return PostResponse.newResponse(LIKE_CANCEL_SUCCESS);
+        }
+    }
+
 }

--- a/src/main/java/server/sookdak/constants/ExceptionCode.java
+++ b/src/main/java/server/sookdak/constants/ExceptionCode.java
@@ -29,6 +29,7 @@ public enum ExceptionCode {
     /* 404 - 찾을 수 없는 리소스 */
     MEMBER_EMAIL_NOT_FOUND(NOT_FOUND, "가입되지 않은 이메일입니다."),
     BOARD_NOT_FOUND(NOT_FOUND, "게시판을 찾을 수 없습니다."),
+    POST_NOT_FOUND(NOT_FOUND, "게시글을 찾을 수 없습니다."),
 
     /* 409 - 중복된 리소스 */
     DUPLICATE_BOARD_NAME(CONFLICT, "이미 해당 이름을 가진 게시판이 있습니다.");

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -23,7 +23,9 @@ public enum SuccessCode {
 
     STAR_SUCCESS(OK, "게시판 즐겨찾기에 성공했습니다."),
     STAR_CANCEL_SUCCESS(OK, "게시판 즐겨찾기 취소에 성공했습니다."),
-    STAR_INFO_SUCCESS(OK, "게시판 즐겨찾기 조회에 성공했습니다.");
+    STAR_INFO_SUCCESS(OK, "게시판 즐겨찾기 조회에 성공했습니다."),
+    LIKE_SUCCESS(OK, "게시글 공감에 성공했습니다."),
+    LIKE_CANCEL_SUCCESS(OK, "게시글 공감 취소에 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/server/sookdak/domain/Post.java
+++ b/src/main/java/server/sookdak/domain/Post.java
@@ -3,6 +3,8 @@ package server.sookdak.domain;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -20,10 +22,12 @@ public class Post {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Board board;
 
     @Column(length = 2000)
@@ -31,10 +35,11 @@ public class Post {
 
     private String createdAt;
 
-    private Long liked;
-
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<PostImage> images = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<PostLike> likes = new ArrayList<>();
 
     public static Post createPost(User user, Board board, String content, String createdAt) {
         Post post = new Post();
@@ -42,7 +47,6 @@ public class Post {
         post.board = board;
         post.content = content;
         post.createdAt = createdAt;
-        post.liked = 0L;
         return post;
     }
 }

--- a/src/main/java/server/sookdak/domain/PostLike.java
+++ b/src/main/java/server/sookdak/domain/PostLike.java
@@ -1,0 +1,34 @@
+package server.sookdak.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostLike {
+
+    @EmbeddedId
+    private UserPostId userPostId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    @MapsId("userId")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    @MapsId("postId")
+    private Post post;
+
+    public static PostLike createPostLike(User user, Post post) {
+        PostLike postLike = new PostLike();
+        postLike.userPostId = new UserPostId(user.getUserId(), post.getPostId());
+        postLike.user = user;
+        postLike.post = post;
+        return postLike;
+    }
+}

--- a/src/main/java/server/sookdak/domain/UserPostId.java
+++ b/src/main/java/server/sookdak/domain/UserPostId.java
@@ -1,0 +1,21 @@
+package server.sookdak.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserPostId implements Serializable {
+    private Long userId;
+    private Long postId;
+
+    public UserPostId(Long userId, Long postId) {
+        this.userId = userId;
+        this.postId = postId;
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/PostListResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/PostListResponseDto.java
@@ -24,14 +24,14 @@ public class PostListResponseDto {
         private Long postId;
         private String content;
         private String createdAt;
-        private Long liked;
+        private int likes;
         private boolean image;
 
-        public PostList(Post entity, boolean image) {
+        public PostList(Post entity, boolean image, int likes) {
             this.postId = entity.getPostId();
             this.content = entity.getContent();
             this.createdAt = entity.getCreatedAt();
-            this.liked = entity.getLiked();
+            this.likes = likes;
             this.image = image;
         }
     }

--- a/src/main/java/server/sookdak/repository/PostLikeRepository.java
+++ b/src/main/java/server/sookdak/repository/PostLikeRepository.java
@@ -1,0 +1,14 @@
+package server.sookdak.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.sookdak.domain.Post;
+import server.sookdak.domain.PostLike;
+import server.sookdak.domain.User;
+import server.sookdak.domain.UserPostId;
+
+import java.util.Optional;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, UserPostId> {
+
+    Optional<PostLike> findByUserAndPost(User user, Post post);
+}

--- a/src/main/java/server/sookdak/repository/PostRepository.java
+++ b/src/main/java/server/sookdak/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package server.sookdak.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import server.sookdak.domain.Board;
 import server.sookdak.domain.Post;
 
@@ -8,7 +9,8 @@ import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    List<Post> findAllByBoardOrderByCreatedAtDesc(Board board);
+    List<Post> findAllByBoardOrderByCreatedAtDescPostIdDesc(Board board);
 
-    List<Post> findAllByBoardOrderByLikedDescCreatedAtDesc(Board board);
+    @Query("select p from Post p where p.board=?1 order by p.likes.size desc, p.createdAt desc, p.postId desc")
+     List<Post> findAllByBoardOrderByLikesDescCreatedAtDesc(Board board);
 }


### PR DESCRIPTION
## 작업사항
<!-- 이 밑에 작업사항 설명이랑, 리뷰어가 어떤 부분 집중하면 좋을지 쓰면 됩니다 -->
게시글 공감 API 만들었습니다~~~~~~~
그리고 Post 쪽에 공감수 필드 만들어놨던거 삭제했고, Post랑 PostLike 양방향 연관관계로 설정했어요
그래서 게시글 목록 조회 API 쪽에서도 공감순 정렬 코드 수정해야 해서 수정했습니당
closed #33 

## 테스트
### 게시글 공감 SUCCESS
<img width="746" alt="스크린샷 2022-04-09 오후 12 57 43" src="https://user-images.githubusercontent.com/73515587/162555925-ec1ec0e8-ef00-498e-a075-9ffefe20fa2f.png">

### 게시글 공감 취소 SUCCESS
<img width="746" alt="스크린샷 2022-04-09 오후 12 57 47" src="https://user-images.githubusercontent.com/73515587/162555929-4ab7de16-54c7-46f3-aba3-0acb5ceaa578.png">

### 게시글 공감 FAIL - 잘못된 게시글 id
<img width="752" alt="스크린샷 2022-04-09 오후 1 16 45" src="https://user-images.githubusercontent.com/73515587/162555948-bf9119df-d2a1-4eb1-b633-f178a9c552d5.png">

### 게시글 목록 공감순 조회 SUCCESS
<img width="1360" alt="스크린샷 2022-04-09 오후 1 10 05" src="https://user-images.githubusercontent.com/73515587/162555980-8d2e2324-eabd-400e-bc00-b511d5b4d9d8.png">
