### PR TITLE
[FIX] 게시글 목록 조회 API 수정

### DIFF
--- a/src/main/java/server/sookdak/SookdakApplication.java
+++ b/src/main/java/server/sookdak/SookdakApplication.java
@@ -3,8 +3,16 @@ package server.sookdak;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class SookdakApplication {
+
+	@PostConstruct
+	public void started() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(SookdakApplication.class, args);

--- a/src/main/java/server/sookdak/api/PostApi.java
+++ b/src/main/java/server/sookdak/api/PostApi.java
@@ -49,9 +49,9 @@ public class PostApi {
         return PostResponse.newResponse(POST_SAVE_SUCCESS);
     }
 
-    @GetMapping("/{order}/{boardId}")
-    public ResponseEntity<PostListResponse> postList(@PathVariable Long boardId, @PathVariable String order) {
-        PostListResponseDto responseDto = postService.getPostList(boardId, order);
+    @GetMapping("/{order}/{boardId}/{page}")
+    public ResponseEntity<PostListResponse> postList(@PathVariable Long boardId, @PathVariable String order, @PathVariable int page) {
+        PostListResponseDto responseDto = postService.getPostList(boardId, order, page);
 
         return PostListResponse.newResponse(POST_LIST_READ_SUCCESS, responseDto);
     }

--- a/src/main/java/server/sookdak/dto/res/PostListResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/PostListResponseDto.java
@@ -9,14 +9,16 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class PostListResponseDto {
+    private boolean star;
     private List<PostList> posts;
 
-    private PostListResponseDto(List<PostList> posts) {
+    private PostListResponseDto(boolean star, List<PostList> posts) {
+        this.star = star;
         this.posts = posts;
     }
 
-    public static PostListResponseDto of(List<PostList> posts) {
-        return new PostListResponseDto(posts);
+    public static PostListResponseDto of(boolean star, List<PostList> posts) {
+        return new PostListResponseDto(star, posts);
     }
 
     @Getter

--- a/src/main/java/server/sookdak/repository/PostRepository.java
+++ b/src/main/java/server/sookdak/repository/PostRepository.java
@@ -1,5 +1,7 @@
 package server.sookdak.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import server.sookdak.domain.Board;
@@ -9,8 +11,8 @@ import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    List<Post> findAllByBoardOrderByCreatedAtDescPostIdDesc(Board board);
+    Page<Post> findAllByBoardOrderByCreatedAtDescPostIdDesc(Board board, Pageable page);
 
     @Query("select p from Post p where p.board=?1 order by p.likes.size desc, p.createdAt desc, p.postId desc")
-     List<Post> findAllByBoardOrderByLikesDescCreatedAtDesc(Board board);
+     List<Post> findAllByBoardOrderByLikesDescCreatedAtDesc(Board board, Pageable page);
 }

--- a/src/main/java/server/sookdak/repository/StarRepsository.java
+++ b/src/main/java/server/sookdak/repository/StarRepsository.java
@@ -13,5 +13,7 @@ public interface StarRepsository extends JpaRepository<Star, StarId> {
 
     Optional<Star> findByUserAndBoard(User user, Board board);
 
+    boolean existsByUserAndBoard(User user, Board board);
+
     List<Star> findAllByUserOrderByCreatedAtAsc(User user);
 }

--- a/src/main/java/server/sookdak/service/PostService.java
+++ b/src/main/java/server/sookdak/service/PostService.java
@@ -60,7 +60,7 @@ public class PostService {
                 .orElseThrow(() -> new CustomException(BOARD_NOT_FOUND));
 
         List<PostList> posts = new ArrayList<>();
-        PageRequest pageRequest = PageRequest.of(page, 10);
+        PageRequest pageRequest = PageRequest.of(page, 20);
         if (order.equals("latest")) {
             posts = postRepository.findAllByBoardOrderByCreatedAtDescPostIdDesc(board, pageRequest).stream()
                     .map(post -> new PostList(post, post.getImages().size() != 0, post.getLikes().size()))

--- a/src/main/java/server/sookdak/service/PostService.java
+++ b/src/main/java/server/sookdak/service/PostService.java
@@ -1,6 +1,7 @@
 package server.sookdak.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.sookdak.domain.*;
@@ -28,6 +29,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final PostLikeRepository postLikeRepository;
     private final PostImageRepository postImageRepository;
+    private final StarRepsository starRepsository;
     private final BoardRepository boardRepository;
     private final UserRepository userRepository;
 
@@ -49,7 +51,7 @@ public class PostService {
         postRepository.save(post);
     }
 
-    public PostListResponseDto getPostList(Long boardId, String order) {
+    public PostListResponseDto getPostList(Long boardId, String order, int page) {
         String userEmail = SecurityUtil.getCurrentUserEmail();
         User user = userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -58,19 +60,21 @@ public class PostService {
                 .orElseThrow(() -> new CustomException(BOARD_NOT_FOUND));
 
         List<PostList> posts = new ArrayList<>();
+        PageRequest pageRequest = PageRequest.of(page, 10);
         if (order.equals("latest")) {
-            posts = postRepository.findAllByBoardOrderByCreatedAtDescPostIdDesc(board).stream()
+            posts = postRepository.findAllByBoardOrderByCreatedAtDescPostIdDesc(board, pageRequest).stream()
                     .map(post -> new PostList(post, post.getImages().size() != 0, post.getLikes().size()))
                     .collect(Collectors.toList());
         } else if (order.equals("popularity")) {
-            posts = postRepository.findAllByBoardOrderByLikesDescCreatedAtDesc(board).stream()
+            posts = postRepository.findAllByBoardOrderByLikesDescCreatedAtDesc(board, pageRequest).stream()
                     .map(post -> new PostList(post, post.getImages().size() != 0, post.getLikes().size()))
                     .collect(Collectors.toList());
         } else {
             throw new CustomException(WRONG_TYPE_ORDER);
         }
 
-        return PostListResponseDto.of(posts);
+        boolean isStar = starRepsository.existsByUserAndBoard(user, board);
+        return PostListResponseDto.of(isStar, posts);
     }
 
     public boolean clickPostLike(Long postId) {


### PR DESCRIPTION
## 작업사항
<!-- 이 밑에 작업사항 설명이랑, 리뷰어가 어떤 부분 집중하면 좋을지 쓰면 됩니다 -->
일단 uri를 변경했습니다!! API 명세서에 자세히 작성해뒀고 페이징 처리를 위해서 몇번째 페이지인지 보내도록 uri에 추가했습니다
그리고 해당 게시판을 유저가 즐겨찾기 했는지 여부도 보내야해서 그 부분도 추가했어요
한 번에 게시글 20개씩 보내는 걸로 설정했습니다~~
closed #37 

## 테스트
### 게시글 목록 조회 최신순 SUCCESS
<img width="752" alt="스크린샷 2022-04-10 오후 1 45 18" src="https://user-images.githubusercontent.com/73515587/162602417-bca13462-77bf-43ee-9590-89fecbbcdc68.png">

### 게시글 목록 조회 공감순 SUCCESS
<img width="752" alt="스크린샷 2022-04-10 오후 1 45 12" src="https://user-images.githubusercontent.com/73515587/162602434-54d9813a-bcf3-4aa6-816d-a8826bf90ffb.png">
