### PR TITLE
[FEAT] 게시글 삭제 API

### DIFF
--- a/src/main/java/server/sookdak/api/PostApi.java
+++ b/src/main/java/server/sookdak/api/PostApi.java
@@ -49,6 +49,13 @@ public class PostApi {
         return PostResponse.newResponse(POST_SAVE_SUCCESS);
     }
 
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<PostResponse> deletePost(@PathVariable Long postId) {
+        postService.deletePost(postId);
+
+        return PostResponse.newResponse(POST_DELETE_SUCCESS);
+    }
+
     @GetMapping("/{order}/{boardId}/{page}")
     public ResponseEntity<PostListResponse> postList(@PathVariable Long boardId, @PathVariable String order, @PathVariable int page) {
         PostListResponseDto responseDto = postService.getPostList(boardId, order, page);

--- a/src/main/java/server/sookdak/constants/ExceptionCode.java
+++ b/src/main/java/server/sookdak/constants/ExceptionCode.java
@@ -26,6 +26,7 @@ public enum ExceptionCode {
     FORBIDDEN_ACCESS(FORBIDDEN, "허용되지 않은 접근입니다."),
     SOOKMYUNG_ONLY(FORBIDDEN, "숙명 계정으로 로그인해야 합니다."),
     LIKE_DENIED(FORBIDDEN, "본인이 쓴 글은 공감할 수 없습니다."),
+    WRITER_ONLY(FORBIDDEN, "본인이 쓴 글만 삭제할 수 있습니다."),
 
     /* 404 - 찾을 수 없는 리소스 */
     MEMBER_EMAIL_NOT_FOUND(NOT_FOUND, "가입되지 않은 이메일입니다."),

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -20,6 +20,7 @@ public enum SuccessCode {
 
     POST_SAVE_SUCCESS(OK, "게시글 저장에 성공했습니다."),
     POST_LIST_READ_SUCCESS(OK, "게시글 목록 조회에 성공했습니다."),
+    POST_DELETE_SUCCESS(OK, "게시글 삭제에 성공했습니다."),
 
     STAR_SUCCESS(OK, "게시판 즐겨찾기에 성공했습니다."),
     STAR_CANCEL_SUCCESS(OK, "게시판 즐겨찾기 취소에 성공했습니다."),

--- a/src/main/java/server/sookdak/service/PostService.java
+++ b/src/main/java/server/sookdak/service/PostService.java
@@ -52,6 +52,22 @@ public class PostService {
         postRepository.save(post);
     }
 
+
+    public void deletePost(Long postId) {
+        String userEmail = SecurityUtil.getCurrentUserEmail();
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+
+        if (post.getUser() != user) {
+            throw new CustomException(WRITER_ONLY);
+        } else {
+            postRepository.delete(post);
+        }
+    }
+
     public PostListResponseDto getPostList(Long boardId, String order, int page) {
         String userEmail = SecurityUtil.getCurrentUserEmail();
         User user = userRepository.findByEmail(userEmail)


### PR DESCRIPTION
## 작업사항
<!-- 이 밑에 작업사항 설명이랑, 리뷰어가 어떤 부분 집중하면 좋을지 쓰면 됩니다 -->
게시글 삭제 API 구현 완료~~!!
본인이 쓴 글인지 확인 후, 본인글이 아니면 예외처리하고 본인글이면 삭제 진행하도록 작성했습니다
해당 게시글에 공감, 스크랩, 게시판 스크랩 달려있을때도 삭제 잘 되는 것 확인~!
closed #44 


## 테스트
### 게시글 삭제 SUCCESS
<img width="744" alt="스크린샷 2022-04-19 오후 3 05 59" src="https://user-images.githubusercontent.com/73515587/163938016-2bbd9431-6f1a-44da-8a3b-4327d3944bb9.png">

### 게시글 삭제 FAIL - 본인이 쓴 글 아닐 경우
<img width="744" alt="스크린샷 2022-04-19 오후 3 05 46" src="https://user-images.githubusercontent.com/73515587/163938042-e9634c43-2df7-4abb-aa31-0b212bd2c77c.png">

### 게시글 삭제 FAIL - 잘못된 게시글 id
<img width="744" alt="스크린샷 2022-04-19 오후 3 12 51" src="https://user-images.githubusercontent.com/73515587/163938066-d603f8ed-9922-41b8-b300-6506ab4c7ea4.png">

