### PR TITLE
[FEAT] 게시글 상세조회 API

### DIFF
--- a/src/main/java/server/sookdak/api/PostApi.java
+++ b/src/main/java/server/sookdak/api/PostApi.java
@@ -4,9 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import server.sookdak.dto.req.PostSaveRequestDto;
-import server.sookdak.dto.res.PostListResponse;
-import server.sookdak.dto.res.PostListResponseDto;
-import server.sookdak.dto.res.PostResponse;
+import server.sookdak.dto.res.*;
 import server.sookdak.service.PostService;
 import server.sookdak.util.S3Util;
 
@@ -54,6 +52,13 @@ public class PostApi {
         postService.deletePost(postId);
 
         return PostResponse.newResponse(POST_DELETE_SUCCESS);
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostDetailResponse> getPostDetail(@PathVariable Long postId) {
+        PostDetailResponseDto responseDto = postService.getPostDetail(postId);
+
+        return PostDetailResponse.newResponse(POST_DETAIL_READ_SUCCESS, responseDto);
     }
 
     @GetMapping("/{order}/{boardId}/{page}")

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -19,6 +19,7 @@ public enum SuccessCode {
     BOARD_DELETE_SUCCESS(OK, "게시판 삭제에 성공했습니다."),
 
     POST_SAVE_SUCCESS(OK, "게시글 저장에 성공했습니다."),
+    POST_DETAIL_READ_SUCCESS(OK, "게시글 상세 조회에 성공했습니다."),
     POST_LIST_READ_SUCCESS(OK, "게시글 목록 조회에 성공했습니다."),
     POST_DELETE_SUCCESS(OK, "게시글 삭제에 성공했습니다."),
 

--- a/src/main/java/server/sookdak/dto/res/PostDetailResponse.java
+++ b/src/main/java/server/sookdak/dto/res/PostDetailResponse.java
@@ -1,0 +1,25 @@
+package server.sookdak.dto.res;
+
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+
+@Getter
+public class PostDetailResponse extends BaseResponse {
+    PostDetailResponseDto data;
+
+    private PostDetailResponse(Boolean success, String message, PostDetailResponseDto data) {
+        super(success, message);
+        this.data = data;
+    }
+
+    public static PostDetailResponse of(Boolean success, String message, PostDetailResponseDto data) {
+        return new PostDetailResponse(success, message, data);
+    }
+
+    public static ResponseEntity<PostDetailResponse> newResponse(SuccessCode code, PostDetailResponseDto data) {
+        PostDetailResponse response = PostDetailResponse.of(true, code.getMessage(), data);
+        return new ResponseEntity<>(response, code.getStatus());
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/PostDetailResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/PostDetailResponseDto.java
@@ -1,0 +1,60 @@
+package server.sookdak.dto.res;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PostDetailResponseDto {
+    private PostDetail post;
+    private List<CommentList> comments;
+
+    private PostDetailResponseDto(PostDetail post, List<CommentList> comments) {
+        this.post = post;
+        this.comments = comments;
+    }
+
+    public static PostDetailResponseDto of(PostDetail post, List<CommentList> comments) {
+        return new PostDetailResponseDto(post, comments);
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class PostDetail {
+        private String content;
+        private String createdAt;
+        private int likes;
+        private int scraps;
+        private List<String> images;
+        private boolean writer;
+
+        public PostDetail(String content, String createdAt, int likes, int scraps, List<String> images, boolean writer) {
+            this.content = content;
+            this.createdAt = createdAt;
+            this.likes = likes;
+            this.scraps = scraps;
+            this.images = images;
+            this.writer = writer;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class CommentList {
+        private Long commentId;
+        private String content;
+        private String createdAt;
+        private int likes;
+        private String image;
+
+        public CommentList(Long commentId, String content, String createdAt, int likes, String image) {
+            this.commentId = commentId;
+            this.content = content;
+            this.createdAt = createdAt;
+            this.likes = likes;
+            this.image = image;
+        }
+    }
+}

--- a/src/main/java/server/sookdak/repository/PostScrapRepository.java
+++ b/src/main/java/server/sookdak/repository/PostScrapRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 
 public interface PostScrapRepository extends JpaRepository<PostScrap, UserPostId> {
     Optional<PostScrap> findByUserAndPost(User user, Post post);
+
+    int countByPost(Post post);
 }


### PR DESCRIPTION
## 작업사항
<!-- 이 밑에 작업사항 설명이랑, 리뷰어가 어떤 부분 집중하면 좋을지 쓰면 됩니다 -->
게시글 상세조회 API 만들었습니다~~~~~
게시글에 대한 정보 (내용, 작성일자, 좋아요수, 스크랩수, 이미지경로, 로그인한 유저가 글쓴이인지 여부) 보내주는 거만 했고
댓글에 대한 정보는 댓글 작성 완성하고 나면 추가할게요!!!
closed #46 

## 테스트
### 게시글 상세조회 SUCCESS
<img width="752" alt="스크린샷 2022-04-28 오전 11 21 10" src="https://user-images.githubusercontent.com/73515587/165664244-58870c91-70bb-4b7a-aa9f-d92c4e3a6a94.png">

### 게시글 상세조회 FAIL - 잘못된 게시글 id
<img width="752" alt="스크린샷 2022-04-28 오전 11 21 17" src="https://user-images.githubusercontent.com/73515587/165664282-b2879614-79d9-4914-8c9b-2b2933d8e49b.png">

