### PR TITLE
[FIX] 게시글 삭제 API 수정

### DIFF
--- a/src/main/java/server/sookdak/constants/ExceptionCode.java
+++ b/src/main/java/server/sookdak/constants/ExceptionCode.java
@@ -27,7 +27,7 @@ public enum ExceptionCode {
     SOOKMYUNG_ONLY(FORBIDDEN, "숙명 계정으로 로그인해야 합니다."),
     LIKE_DENIED(FORBIDDEN, "본인이 쓴 글은 공감할 수 없습니다."),
     WRITER_ONLY_EDIT(FORBIDDEN, "본인이 쓴 글만 수정할 수 있습니다."),
-    WRITER_ONLY(FORBIDDEN, "본인이 쓴 글만 삭제할 수 있습니다."),
+    WRITER_ONLY_DELETE(FORBIDDEN, "본인이 쓴 글만 삭제할 수 있습니다."),
     SCRAP_DENIED(FORBIDDEN, "본인이 쓴 글은 스크랩할 수 없습니다."),
 
     /* 404 - 찾을 수 없는 리소스 */

--- a/src/main/java/server/sookdak/service/PostService.java
+++ b/src/main/java/server/sookdak/service/PostService.java
@@ -111,8 +111,13 @@ public class PostService {
                 .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
 
         if (post.getUser() != user) {
-            throw new CustomException(WRITER_ONLY);
+            throw new CustomException(WRITER_ONLY_DELETE);
         } else {
+            if (post.getImages().size() > 0) {
+                postImageRepository.findAllByPost(post)
+                        .forEach(postImage -> s3Util.delete(postImage.getUrl()));
+            }
+
             postRepository.delete(post);
         }
     }


### PR DESCRIPTION
## 작업사항
<!-- 이 밑에 작업사항 설명이랑, 리뷰어가 어떤 부분 집중하면 좋을지 쓰면 됩니다 -->
삭제하려는 게시글에 이미지파일이 있는 경우 S3 bucket에서도 파일 삭제하도록 코드 추가했습니다
closed #57 

## 테스트
S3에서 파일 삭제되는 것 확인 완료~~