### PR TITLE
[FEAT] 댓글 작성 API

### DIFF
--- a/src/main/java/server/sookdak/api/CommentApi.java
+++ b/src/main/java/server/sookdak/api/CommentApi.java
@@ -1,0 +1,35 @@
+package server.sookdak.api;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import server.sookdak.dto.req.CommentSaveRequestDto;
+import server.sookdak.dto.res.CommentResponse;
+import server.sookdak.dto.res.CommentResponseDto;
+import server.sookdak.service.CommentService;
+import server.sookdak.util.S3Util;
+
+import javax.validation.Valid;
+import java.io.IOException;
+
+import static server.sookdak.constants.SuccessCode.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/comment/{postId}")
+public class CommentApi {
+
+    private final CommentService commentService;
+    private final S3Util s3Util;
+
+    @PostMapping("/{parent}/save")
+    public ResponseEntity<CommentResponse> saveComment(@PathVariable Long postId, @PathVariable Long parent, @Valid @ModelAttribute CommentSaveRequestDto commentSaveRequestDto) throws IOException {
+        String imageURL = null;
+        if (commentSaveRequestDto.getImage() != null) {
+            imageURL = s3Util.commentUpload(commentSaveRequestDto.getImage());
+        }
+        CommentResponseDto responseDto = commentService.saveComment(commentSaveRequestDto, postId, parent,imageURL);
+        return CommentResponse.newResponse(COMMENT_SAVE_SUCCESS, responseDto);
+    }
+}

--- a/src/main/java/server/sookdak/config/SecurityConfig.java
+++ b/src/main/java/server/sookdak/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/api/board/**").permitAll()
                 .antMatchers("/api/post/**").permitAll()
                 .antMatchers("/api/star/**").permitAll()
+                .antMatchers("/api/comment/**").permitAll()
                 .anyRequest().authenticated() //나머지 요청은 모두 인증 필요
 
                 //JwtFilter를 addFilterBefore로 등록했던 JwtSecurityConfig 클래스 적용

--- a/src/main/java/server/sookdak/constants/ExceptionCode.java
+++ b/src/main/java/server/sookdak/constants/ExceptionCode.java
@@ -28,14 +28,20 @@ public enum ExceptionCode {
     LIKE_DENIED(FORBIDDEN, "본인이 쓴 글은 공감할 수 없습니다."),
     WRITER_ONLY(FORBIDDEN, "본인이 쓴 글만 삭제할 수 있습니다."),
     SCRAP_DENIED(FORBIDDEN, "본인이 쓴 글은 스크랩할 수 없습니다."),
+    RE_COMMENT_ONLY(FORBIDDEN, "댓글은 답글까지만 달 수 있습니다."),
 
     /* 404 - 찾을 수 없는 리소스 */
     MEMBER_EMAIL_NOT_FOUND(NOT_FOUND, "가입되지 않은 이메일입니다."),
     BOARD_NOT_FOUND(NOT_FOUND, "게시판을 찾을 수 없습니다."),
     POST_NOT_FOUND(NOT_FOUND, "게시글을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(FORBIDDEN, "댓글을 찾을 수 없습니다."),
 
     /* 409 - 중복된 리소스 */
     DUPLICATE_BOARD_NAME(CONFLICT, "이미 해당 이름을 가진 게시판이 있습니다.");
+
+
+
+
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -32,7 +32,9 @@ public enum SuccessCode {
     HOME_INFO_SUCCESS(OK, "홈 조회에 성공했습니다."),
 
     SCRAP_SUCCESS(OK, "게시글 스크랩에 성공했습니다."),
-    SCRAP_DELETE_SUCCESS(OK, "게시글 스크랩 취소에 성공했습니다.");
+    SCRAP_DELETE_SUCCESS(OK, "게시글 스크랩 취소에 성공했습니다."),
+
+    COMMENT_SAVE_SUCCESS(OK, "댓글 작성에 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/server/sookdak/domain/Comment.java
+++ b/src/main/java/server/sookdak/domain/Comment.java
@@ -1,0 +1,52 @@
+package server.sookdak.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment {
+
+    @Id
+    @Column(name = "comment_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Post post;
+
+    @Column(length = 2000)
+    private String content;
+
+    private String createdAt;
+
+    private Long parent;
+
+    @OneToOne(mappedBy = "comment", cascade = CascadeType.ALL)
+    private CommentImage image;
+
+    public static Comment createComment(User user, Post post, Long parent, String content, String createdAt){
+        Comment comment = new Comment();
+        comment.user = user;
+        comment.post = post;
+        comment.parent = parent;
+        comment.content = content;
+        comment.createdAt = createdAt;
+        return comment;
+    }
+
+
+}

--- a/src/main/java/server/sookdak/domain/CommentIdentifier.java
+++ b/src/main/java/server/sookdak/domain/CommentIdentifier.java
@@ -1,0 +1,41 @@
+package server.sookdak.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentIdentifier {
+
+    @EmbeddedId
+    private UserPostId userPostId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    @MapsId("userId")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="post_id")
+    @MapsId("postId")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Post post;
+
+    private int commentOrder;
+
+    public static CommentIdentifier createCommentIdentifier(User user, Post post, int commentOrder){
+        CommentIdentifier commentIdentifier = new CommentIdentifier();
+        commentIdentifier.userPostId = new UserPostId(user.getUserId(), post.getPostId());
+        commentIdentifier.user = user;
+        commentIdentifier.post = post;
+        commentIdentifier.commentOrder = commentOrder;
+        return commentIdentifier;
+    }
+}

--- a/src/main/java/server/sookdak/domain/CommentImage.java
+++ b/src/main/java/server/sookdak/domain/CommentImage.java
@@ -1,0 +1,33 @@
+package server.sookdak.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentImage {
+    @Id
+    @Column(name = "comment_image_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commentImageId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="comment_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Comment comment;
+
+    private String url;
+
+    public static CommentImage createCommentImage(Comment comment, String url){
+        CommentImage commentImage = new CommentImage();
+        commentImage.comment = comment;
+        commentImage.url = url;
+        return commentImage;
+    }
+}

--- a/src/main/java/server/sookdak/domain/Post.java
+++ b/src/main/java/server/sookdak/domain/Post.java
@@ -41,6 +41,9 @@ public class Post {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<PostLike> likes = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<CommentIdentifier> identifiers = new ArrayList<>();
+
     public static Post createPost(User user, Board board, String content, String createdAt) {
         Post post = new Post();
         post.user = user;

--- a/src/main/java/server/sookdak/dto/req/CommentSaveRequestDto.java
+++ b/src/main/java/server/sookdak/dto/req/CommentSaveRequestDto.java
@@ -1,0 +1,17 @@
+package server.sookdak.dto.req;
+
+import lombok.Data;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+public class CommentSaveRequestDto {
+    @NotBlank(message = "댓글 내용이 없습니다.")
+    @Length(max = 2000, message = "글자수가 2000자를 초과했습니다.")
+    private String content;
+
+    private MultipartFile image;
+
+}

--- a/src/main/java/server/sookdak/dto/res/CommentResponse.java
+++ b/src/main/java/server/sookdak/dto/res/CommentResponse.java
@@ -1,0 +1,26 @@
+package server.sookdak.dto.res;
+
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+
+@Getter
+public class CommentResponse extends BaseResponse {
+    CommentResponseDto data;
+
+    private CommentResponse(Boolean success, String message, CommentResponseDto data){
+        super(success, message);
+        this.data = data;
+    }
+
+    public static CommentResponse of(Boolean success, String message, CommentResponseDto data) {
+
+        return new CommentResponse(success, message, data);
+    }
+
+    public static ResponseEntity<CommentResponse> newResponse(SuccessCode code, CommentResponseDto data) {
+        CommentResponse response = CommentResponse.of(true, code.getMessage(), data);
+        return new ResponseEntity(response, code.getStatus());
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/CommentResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/CommentResponseDto.java
@@ -1,0 +1,31 @@
+package server.sookdak.dto.res;
+
+import lombok.Getter;
+import server.sookdak.domain.Comment;
+
+@Getter
+public class CommentResponseDto {
+    private int commentOrder;
+    private Long comment_id;
+    private Long parent;
+    private String content;
+    private String imageURL;
+    private String createdAt;
+
+
+    private CommentResponseDto(int commentOrder, Comment entity, String imageURL) {
+        this.commentOrder = commentOrder;
+        this.comment_id = entity.getCommentId();
+        this.parent = entity.getParent();
+        this.content = entity.getContent();
+        this.imageURL = imageURL;
+        this.createdAt = entity.getCreatedAt();
+
+    }
+
+    public static CommentResponseDto of(int commentOrder, Comment entity, String imageURL) {
+        return new CommentResponseDto(commentOrder, entity,imageURL);
+    }
+}
+
+

--- a/src/main/java/server/sookdak/repository/CommentIdentifierRepository.java
+++ b/src/main/java/server/sookdak/repository/CommentIdentifierRepository.java
@@ -1,0 +1,15 @@
+package server.sookdak.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.sookdak.domain.CommentIdentifier;
+import server.sookdak.domain.Post;
+import server.sookdak.domain.User;
+import server.sookdak.domain.UserPostId;
+
+import java.util.Optional;
+
+public interface CommentIdentifierRepository extends JpaRepository<CommentIdentifier, UserPostId> {
+
+    Optional<CommentIdentifier> findByUserAndPost(User user, Post post);
+
+}

--- a/src/main/java/server/sookdak/repository/CommentImageRepository.java
+++ b/src/main/java/server/sookdak/repository/CommentImageRepository.java
@@ -1,0 +1,7 @@
+package server.sookdak.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.sookdak.domain.CommentImage;
+
+public interface CommentImageRepository extends JpaRepository<CommentImage, Long>{
+}

--- a/src/main/java/server/sookdak/repository/CommentRepository.java
+++ b/src/main/java/server/sookdak/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package server.sookdak.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.sookdak.domain.Comment;
+
+public interface CommentRepository extends JpaRepository<Comment,Long> {
+}
+

--- a/src/main/java/server/sookdak/service/CommentService.java
+++ b/src/main/java/server/sookdak/service/CommentService.java
@@ -1,0 +1,57 @@
+package server.sookdak.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.sookdak.domain.*;
+import server.sookdak.dto.req.CommentSaveRequestDto;
+import server.sookdak.dto.res.CommentResponseDto;
+import server.sookdak.exception.CustomException;
+import server.sookdak.repository.*;
+import server.sookdak.util.SecurityUtil;
+
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+import static server.sookdak.constants.ExceptionCode.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final CommentIdentifierRepository commentIdentifierRepository;
+    private final CommentImageRepository commentImageRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    public CommentResponseDto saveComment(CommentSaveRequestDto commentSaveRequestDto, Long postId, Long parent, String imageURL) {
+        String userEmail = SecurityUtil.getCurrentUserEmail();
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+        Comment comment = Comment.createComment(user, post, parent, commentSaveRequestDto.getContent(), LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm")));
+
+        if (commentSaveRequestDto.getImage() != null) {
+            CommentImage commentImage = CommentImage.createCommentImage(comment, imageURL);
+            commentImageRepository.save(commentImage);
+        }
+
+        commentRepository.save(comment);
+
+        Optional<CommentIdentifier> existCommentIdentifier = commentIdentifierRepository.findByUserAndPost(user, post);
+        CommentIdentifier commentIdentifier;
+        if (existCommentIdentifier.isPresent()) {
+            commentIdentifier = existCommentIdentifier.get();
+        } else {
+            commentIdentifier = CommentIdentifier.createCommentIdentifier(user, post, post.getIdentifiers().size() + 1);
+            commentIdentifierRepository.save(commentIdentifier);
+        }
+
+        return CommentResponseDto.of(commentIdentifier.getCommentOrder(),comment, imageURL);
+    }
+}

--- a/src/main/java/server/sookdak/service/CommentService.java
+++ b/src/main/java/server/sookdak/service/CommentService.java
@@ -34,8 +34,16 @@ public class CommentService {
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
-        Comment comment = Comment.createComment(user, post, parent, commentSaveRequestDto.getContent(), LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm")));
 
+        if (parent != 0) { //대댓글일 경우에
+            if (commentRepository.findById(parent).isEmpty()) { //부모댓글이 존재하지 않는다면
+                throw new CustomException(COMMENT_NOT_FOUND);
+            } else if (commentRepository.findById(parent).get().getParent() != 0) { //부모댓글의 부모가 0이 아니라면
+                throw new CustomException(RE_COMMENT_ONLY);
+            }
+        }
+
+        Comment comment = Comment.createComment(user, post, parent, commentSaveRequestDto.getContent(), LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm")));
         if (commentSaveRequestDto.getImage() != null) {
             CommentImage commentImage = CommentImage.createCommentImage(comment, imageURL);
             commentImageRepository.save(commentImage);
@@ -52,6 +60,6 @@ public class CommentService {
             commentIdentifierRepository.save(commentIdentifier);
         }
 
-        return CommentResponseDto.of(commentIdentifier.getCommentOrder(),comment, imageURL);
+        return CommentResponseDto.of(commentIdentifier.getCommentOrder(), comment, imageURL);
     }
 }

--- a/src/main/java/server/sookdak/util/S3Util.java
+++ b/src/main/java/server/sookdak/util/S3Util.java
@@ -48,7 +48,7 @@ public class S3Util {
         return upload(file, "post");
     }
 
-    public String commentUpload(MultipartFile file, int num) throws IOException {
+    public String commentUpload(MultipartFile file) throws IOException {
         return upload(file, "comment");
     }
 


### PR DESCRIPTION
## 작업사항
댓글 작성 Api를 만들었어요 closed #40 

우선 프론트에 넘겨주는 정보로는
1. 몇번째 익명인지 commentOrder 넘겨줌
2. 누가 대댓글 달 수 있으니까 comment_id도 넘겨줌
3. 부모댓글 parent 의 comment_id 넘겨줌 -> 만약 부모댓글이 없다면 parent는 0 으로 하면 될것 같아요
4. 댓글내용
5. 이미지 주소
6. 댓글 작성 시간      이렇게입니다

uri가 8080/api/comment/{postId}/{parent}/save
인데, 게시글 아이디 옆에 parent는 부모댓글의 comment_id 에요
만약에 부모댓글 없는 그냥 댓글이라면 parent 는 0으로
부모댓글이 있는 대댓글이라면 parent 는 부모댓글의 comment_id 를 넘겨주면 될것 같습니다

부모댓글이 없는 댓글에만 대댓글을 달 수 있도록 해야하는건데 ,,
그거는 프론트에서 할 수 있는 걸까요 ......? 혹시 제가 ....해야하는거라면 
말씀해주세요.... 프론트에서 할 수 있다고 믿슴다 ㅠ

## 테스트
### 댓글 작성 API 성공
<img width="617" alt="스크린샷 2022-05-03 오후 3 05 21" src="https://user-images.githubusercontent.com/62243967/166412855-400bea80-66e2-4d5a-838c-b33e5926c659.png">

이미지도 잘 들어가는거 확인 했어요

### 댓글 실패(게시글 없을때)
<img width="604" alt="스크린샷 2022-05-03 오후 3 45 48" src="https://user-images.githubusercontent.com/62243967/166414004-5b89df0b-605c-4377-af61-d1fd7d599441.png">

