### PR TITLE
[FEAT] 댓글 삭제 API

### DIFF
--- a/src/main/java/server/sookdak/api/CommentApi.java
+++ b/src/main/java/server/sookdak/api/CommentApi.java
@@ -17,13 +17,13 @@ import static server.sookdak.constants.SuccessCode.*;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/comment/{postId}")
+@RequestMapping("/api/comment")
 public class CommentApi {
 
     private final CommentService commentService;
     private final S3Util s3Util;
 
-    @PostMapping("/{parent}/save")
+    @PostMapping("/{postId}/{parent}/save")
     public ResponseEntity<CommentResponse> saveComment(@PathVariable Long postId, @PathVariable Long parent, @Valid @ModelAttribute CommentSaveRequestDto commentSaveRequestDto) throws IOException {
         String imageURL = null;
         if (commentSaveRequestDto.getImage() != null) {
@@ -31,5 +31,12 @@ public class CommentApi {
         }
         CommentResponseDto responseDto = commentService.saveComment(commentSaveRequestDto, postId, parent,imageURL);
         return CommentResponse.newResponse(COMMENT_SAVE_SUCCESS, responseDto);
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<CommentResponse> deleteComment(@PathVariable Long commentId) {
+        commentService.deleteComment(commentId);
+
+        return CommentResponse.newDeleteResponse(COMMENT_DELETE_SUCCESS);
     }
 }

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -35,7 +35,8 @@ public enum SuccessCode {
     SCRAP_SUCCESS(OK, "게시글 스크랩에 성공했습니다."),
     SCRAP_DELETE_SUCCESS(OK, "게시글 스크랩 취소에 성공했습니다."),
 
-    COMMENT_SAVE_SUCCESS(OK, "댓글 작성에 성공했습니다.");
+    COMMENT_SAVE_SUCCESS(OK, "댓글 작성에 성공했습니다."),
+    COMMENT_DELETE_SUCCESS(OK, "댓글 삭제에 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/server/sookdak/dto/res/CommentResponse.java
+++ b/src/main/java/server/sookdak/dto/res/CommentResponse.java
@@ -14,13 +14,25 @@ public class CommentResponse extends BaseResponse {
         this.data = data;
     }
 
+    private CommentResponse(Boolean success, String message){
+        super(success, message);
+    }
+
     public static CommentResponse of(Boolean success, String message, CommentResponseDto data) {
 
         return new CommentResponse(success, message, data);
     }
 
+    public static CommentResponse ofDelete(Boolean success, String message){
+        return new CommentResponse(success, message);
+    }
+
     public static ResponseEntity<CommentResponse> newResponse(SuccessCode code, CommentResponseDto data) {
         CommentResponse response = CommentResponse.of(true, code.getMessage(), data);
         return new ResponseEntity(response, code.getStatus());
+    }
+
+    public static ResponseEntity<CommentResponse> newDeleteResponse(SuccessCode code){
+        return new ResponseEntity(CommentResponse.ofDelete(true, code.getMessage()), code.getStatus());
     }
 }

--- a/src/main/java/server/sookdak/repository/CommentImageRepository.java
+++ b/src/main/java/server/sookdak/repository/CommentImageRepository.java
@@ -1,7 +1,12 @@
 package server.sookdak.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import server.sookdak.domain.Comment;
 import server.sookdak.domain.CommentImage;
 
+import java.util.Optional;
+
 public interface CommentImageRepository extends JpaRepository<CommentImage, Long>{
+    Optional<CommentImage> findByComment(Comment comment);
+
 }


### PR DESCRIPTION
## 작업사항
댓글 삭제 하는 api 만들었습니다
댓글 작성한 유저인지 확인한 다음에 지울수 있도록 했어요 디비에서 잘 지워짐다!
closed #64 

## 테스트
### 댓글삭제 성공 - 대댓글일 경우/ 사진있는 경우/ 사진없는 경우 다 삭제됨다
근데 ! comment_image url값이 null 일경우, 빈 문자열일 경우에는 안되는데
그건 제가 맨첨에 댓글api 만들때 imageURl 초기값을 "" 이렇게 설정했었던 때가 있었고 null 인때로 설정했던때가 있었어서 안지워지는거였구
지금은 사진추가해야지만 comment_image 객체가 생기니까 상관없을것 같아요
<img width="740" alt="스크린샷 2022-05-04 오후 4 16 45" src="https://user-images.githubusercontent.com/62243967/166639679-1112241e-5ccc-4ed6-9947-7655b45e176c.png">
+밑에 data : null 이 있는 이유..
commentResponse에 data 가 있어서 ..
그래서 data 없는 생성자를 따로 만들어서 했는데 프론트에는 data가 어쩔수없이
null이라도 보여지네요 ㅠㅠ

### 댓글 작성한 유저가 아닌데 삭제하려고 시도했을 경우
<img width="612" alt="스크린샷 2022-05-04 오후 4 18 38" src="https://user-images.githubusercontent.com/62243967/166640107-1c305d20-ab80-43ae-a70a-863438b6ad7c.png">



###없는 댓글을 삭제하려고 시도했을 경우
<img width="603" alt="스크린샷 2022-05-04 오후 4 20 00" src="https://user-images.githubusercontent.com/62243967/166639606-176ae840-794f-49dd-9d2d-f05a97a9a5b7.png">


