### PR TITLE
[FIX] 게시판 삭제 API 수정

### DIFF
--- a/src/main/java/server/sookdak/constants/ExceptionCode.java
+++ b/src/main/java/server/sookdak/constants/ExceptionCode.java
@@ -28,6 +28,7 @@ public enum ExceptionCode {
     LIKE_DENIED(FORBIDDEN, "본인이 쓴 글은 공감할 수 없습니다."),
     WRITER_ONLY_EDIT(FORBIDDEN, "본인이 쓴 글만 수정할 수 있습니다."),
     WRITER_ONLY_DELETE(FORBIDDEN, "본인이 쓴 글만 삭제할 수 있습니다."),
+    CREATOR_ONLY_DELETE(FORBIDDEN, "본인이 만든 게시판만 삭제할 수 있습니다."),
     SCRAP_DENIED(FORBIDDEN, "본인이 쓴 글은 스크랩할 수 없습니다."),
     RE_COMMENT_ONLY(FORBIDDEN, "댓글은 답글까지만 달 수 있습니다."),
 

--- a/src/main/java/server/sookdak/service/BoardService.java
+++ b/src/main/java/server/sookdak/service/BoardService.java
@@ -66,8 +66,15 @@ public class BoardService {
     }
 
     public BoardResponseDto delete(Long BoardId) {
+        String userEmail = SecurityUtil.getCurrentUserEmail();
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
         Board board = boardRepository.findById(BoardId)
                 .orElseThrow(() -> new CustomException(BOARD_NOT_FOUND));
+        if(board.getUser() != user) {
+            throw new CustomException(CREATOR_ONLY_DELETE);
+        }
         boardRepository.delete(board);
         return BoardResponseDto.of(board);
     }


### PR DESCRIPTION
## 작업사항
게시판 삭제 시 본인이 만든 게시판인지 확인하는 코드를 추가했습니다.
closed #71 


## 테스트
### 게시판 삭제 fail
<img width="786" alt="스크린샷 2022-05-06 오후 8 08 18" src="https://user-images.githubusercontent.com/62243967/167121167-532e7667-43a7-42a8-a04e-5d88911ceacf.png">

