### PR TITLE
[FEAT] 내가 스크랩 한 글 조회 API

### DIFF
--- a/src/main/java/server/sookdak/api/UserApi.java
+++ b/src/main/java/server/sookdak/api/UserApi.java
@@ -3,13 +3,12 @@ package server.sookdak.api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import server.sookdak.dto.res.post.*;
 import server.sookdak.dto.res.user.TokenDto;
 import server.sookdak.dto.req.TokenRequestDto;
 import server.sookdak.dto.req.UserRequestDto;
 import server.sookdak.dto.res.board.BoardListResponse;
 import server.sookdak.dto.res.board.BoardListResponseDto;
-import server.sookdak.dto.res.post.MyPostListResponse;
-import server.sookdak.dto.res.post.MyPostListResponseDto;
 import server.sookdak.dto.res.user.TokenResponse;
 import server.sookdak.dto.res.user.UserResponse;
 import server.sookdak.dto.res.user.UserResponseDto;
@@ -61,5 +60,12 @@ public class UserApi {
         MyPostListResponseDto responseDto = postService.getMyPost(page);
 
         return MyPostListResponse.newResponse(POST_LIST_READ_SUCCESS, responseDto);
+    }
+
+    @GetMapping("/myscrap/{page}")
+    public ResponseEntity<ScrapListResponse> myscrap(@PathVariable int page) {
+        ScrapListResponseDto responseDto = postService.getMyScrap(page);
+
+        return ScrapListResponse.newResponse(POST_LIST_READ_SUCCESS,responseDto);
     }
 }

--- a/src/main/java/server/sookdak/dto/res/post/ScrapListResponse.java
+++ b/src/main/java/server/sookdak/dto/res/post/ScrapListResponse.java
@@ -1,0 +1,27 @@
+package server.sookdak.dto.res.post;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+
+@Getter
+@NoArgsConstructor
+public class ScrapListResponse extends BaseResponse {
+    ScrapListResponseDto data;
+
+    private ScrapListResponse(Boolean success, String message, ScrapListResponseDto data) {
+        super(success, message);
+        this.data = data;
+    }
+
+    public static ScrapListResponse of(Boolean success, String message, ScrapListResponseDto data) {
+        return new ScrapListResponse(success, message, data);
+    }
+
+    public static ResponseEntity<ScrapListResponse> newResponse(SuccessCode code, ScrapListResponseDto data) {
+        ScrapListResponse response = ScrapListResponse.of(true, code.getMessage(), data);
+        return new ResponseEntity<>(response, code.getStatus());
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/post/ScrapListResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/post/ScrapListResponseDto.java
@@ -1,0 +1,42 @@
+package server.sookdak.dto.res.post;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.sookdak.domain.PostScrap;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ScrapListResponseDto {
+    private List<ScrapList> scraps;
+
+    private ScrapListResponseDto(List<ScrapList> scraps) { this.scraps = scraps; }
+
+    public static ScrapListResponseDto of(List<ScrapList> scraps) { return new ScrapListResponseDto(scraps); }
+
+    @Getter
+    public static class ScrapList {
+        private Long postId;
+        private String content;
+        private String createdAt;
+        private int likes;
+        private int comments;
+        private boolean image;
+
+        public ScrapList(PostScrap postScrap) {
+            this.postId = postScrap.getPost().getPostId();
+            this.content = postScrap.getPost().getContent();
+            this.createdAt = postScrap.getPost().getCreatedAt();
+            this.likes = postScrap.getPost().getLikes().size();
+            this.comments = postScrap.getPost().getComments().size();
+            if(postScrap.getPost().getImages() != null) {
+                this.image = true;
+            } else {
+                this.image = false;
+            }
+        }
+
+
+    }
+}

--- a/src/main/java/server/sookdak/repository/PostScrapRepository.java
+++ b/src/main/java/server/sookdak/repository/PostScrapRepository.java
@@ -1,15 +1,19 @@
 package server.sookdak.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.sookdak.domain.Post;
 import server.sookdak.domain.PostScrap;
 import server.sookdak.domain.User;
 import server.sookdak.domain.UserPostId;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PostScrapRepository extends JpaRepository<PostScrap, UserPostId> {
     Optional<PostScrap> findByUserAndPost(User user, Post post);
 
     int countByPost(Post post);
+
+    List<PostScrap> findAllByUserOrderByCreatedAtDesc(User user, Pageable page);
 }

--- a/src/main/java/server/sookdak/service/PostService.java
+++ b/src/main/java/server/sookdak/service/PostService.java
@@ -10,6 +10,7 @@ import server.sookdak.dto.res.post.MyPostListResponseDto;
 import server.sookdak.dto.res.post.PostDetailResponseDto;
 import server.sookdak.dto.res.post.PostDetailResponseDto.PostDetail;
 import server.sookdak.dto.res.post.PostListResponseDto;
+import server.sookdak.dto.res.post.ScrapListResponseDto;
 import server.sookdak.exception.CustomException;
 import server.sookdak.repository.*;
 import server.sookdak.util.S3Util;
@@ -228,5 +229,19 @@ public class PostService {
                 .collect(Collectors.toList());
 
         return MyPostListResponseDto.of(posts);
+    }
+
+    public ScrapListResponseDto getMyScrap(int page) {
+        String userEmail = SecurityUtil.getCurrentUserEmail();
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        PageRequest pageRequest = PageRequest.of(page, 20);
+        List<ScrapListResponseDto.ScrapList> scrapLists = postScrapRepository.findAllByUserOrderByCreatedAtDesc(user, pageRequest).stream()
+                .map(ScrapListResponseDto.ScrapList::new)
+                .collect(Collectors.toList());
+
+        return ScrapListResponseDto.of(scrapLists);
+
     }
 }


### PR DESCRIPTION
## 작업사항
유저가 스크랩 한 게시글을 조회할 수 있는 API를 만들었어요
MyPostListResponse 랑 MyPostListResponseDto 재활용하고 싶었는데 ....
먼가 조금씩 달라서 안되더라고 ....?
할 수 있는건데 내가 못하는걸까 ...? 
한번 봐봐주세요... 재활용 할 수 있었던걸까? 뭔가 있을것 같은데 아직 ..좀 머리가 거기까지 안되나바...ㅠ
이거 이슈 열려있는게 넘 거슬려서 채팅방 하기 전에 빨리 끝내고 싶었어요
이제 채팅방 할게 ...

closed #52 

아 그리고 PostRepository에 List<Post> findAllByUserOrderByCreatedAtDescPostIdDesc(User user, Pageable page);
이거는 왜 orderBy 기준이 생성일자랑 postId 이렇게 두개야??
createdAt만 넣어도 만들어진 순서(내림차순)대로 착착 나오는거 아닌감 ??

## 테스트
### 스크랩한 게시글 목록 조회 성공
<img width="620" alt="스크린샷 2022-05-07 오전 1 20 33" src="https://user-images.githubusercontent.com/62243967/167175057-0073b71c-9919-4b0d-a656-e569990dfedd.png">
