### PR TITLE
[FIX] 게시판 조회 API 수정

### DIFF
--- a/src/main/java/server/sookdak/api/UserApi.java
+++ b/src/main/java/server/sookdak/api/UserApi.java
@@ -3,13 +3,12 @@ package server.sookdak.api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import server.sookdak.dto.res.post.*;
 import server.sookdak.dto.res.user.TokenDto;
 import server.sookdak.dto.req.TokenRequestDto;
 import server.sookdak.dto.req.UserRequestDto;
 import server.sookdak.dto.res.board.BoardListResponse;
 import server.sookdak.dto.res.board.BoardListResponseDto;
-import server.sookdak.dto.res.post.MyPostListResponse;
-import server.sookdak.dto.res.post.MyPostListResponseDto;
 import server.sookdak.dto.res.user.TokenResponse;
 import server.sookdak.dto.res.user.UserResponse;
 import server.sookdak.dto.res.user.UserResponseDto;
@@ -61,5 +60,12 @@ public class UserApi {
         MyPostListResponseDto responseDto = postService.getMyPost(page);
 
         return MyPostListResponse.newResponse(POST_LIST_READ_SUCCESS, responseDto);
+    }
+
+    @GetMapping("/myscrap/{page}")
+    public ResponseEntity<ScrapListResponse> myscrap(@PathVariable int page) {
+        ScrapListResponseDto responseDto = postService.getMyScrap(page);
+
+        return ScrapListResponse.newResponse(POST_LIST_READ_SUCCESS,responseDto);
     }
 }

--- a/src/main/java/server/sookdak/dto/res/post/ScrapListResponse.java
+++ b/src/main/java/server/sookdak/dto/res/post/ScrapListResponse.java
@@ -1,0 +1,27 @@
+package server.sookdak.dto.res.post;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+
+@Getter
+@NoArgsConstructor
+public class ScrapListResponse extends BaseResponse {
+    ScrapListResponseDto data;
+
+    private ScrapListResponse(Boolean success, String message, ScrapListResponseDto data) {
+        super(success, message);
+        this.data = data;
+    }
+
+    public static ScrapListResponse of(Boolean success, String message, ScrapListResponseDto data) {
+        return new ScrapListResponse(success, message, data);
+    }
+
+    public static ResponseEntity<ScrapListResponse> newResponse(SuccessCode code, ScrapListResponseDto data) {
+        ScrapListResponse response = ScrapListResponse.of(true, code.getMessage(), data);
+        return new ResponseEntity<>(response, code.getStatus());
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/post/ScrapListResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/post/ScrapListResponseDto.java
@@ -1,0 +1,42 @@
+package server.sookdak.dto.res.post;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.sookdak.domain.PostScrap;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ScrapListResponseDto {
+    private List<ScrapList> scraps;
+
+    private ScrapListResponseDto(List<ScrapList> scraps) { this.scraps = scraps; }
+
+    public static ScrapListResponseDto of(List<ScrapList> scraps) { return new ScrapListResponseDto(scraps); }
+
+    @Getter
+    public static class ScrapList {
+        private Long postId;
+        private String content;
+        private String createdAt;
+        private int likes;
+        private int comments;
+        private boolean image;
+
+        public ScrapList(PostScrap postScrap) {
+            this.postId = postScrap.getPost().getPostId();
+            this.content = postScrap.getPost().getContent();
+            this.createdAt = postScrap.getPost().getCreatedAt();
+            this.likes = postScrap.getPost().getLikes().size();
+            this.comments = postScrap.getPost().getComments().size();
+            if(postScrap.getPost().getImages() != null) {
+                this.image = true;
+            } else {
+                this.image = false;
+            }
+        }
+
+
+    }
+}

--- a/src/main/java/server/sookdak/repository/BoardRepository.java
+++ b/src/main/java/server/sookdak/repository/BoardRepository.java
@@ -8,7 +8,7 @@ import server.sookdak.domain.User;
 import java.util.List;
 
 public interface BoardRepository extends JpaRepository<Board,Long> {
-    @Query("SELECT p FROM Board p ORDER BY p.boardId DESC")
+    @Query("SELECT p FROM Board p ORDER BY p.stars.size DESC")
     List<Board> findAllDesc();
 
     List<Board> findByUser(User user);

--- a/src/main/java/server/sookdak/repository/PostScrapRepository.java
+++ b/src/main/java/server/sookdak/repository/PostScrapRepository.java
@@ -1,15 +1,19 @@
 package server.sookdak.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.sookdak.domain.Post;
 import server.sookdak.domain.PostScrap;
 import server.sookdak.domain.User;
 import server.sookdak.domain.UserPostId;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PostScrapRepository extends JpaRepository<PostScrap, UserPostId> {
     Optional<PostScrap> findByUserAndPost(User user, Post post);
 
     int countByPost(Post post);
+
+    List<PostScrap> findAllByUserOrderByCreatedAtDesc(User user, Pageable page);
 }

--- a/src/main/java/server/sookdak/service/PostService.java
+++ b/src/main/java/server/sookdak/service/PostService.java
@@ -10,6 +10,7 @@ import server.sookdak.dto.res.post.MyPostListResponseDto;
 import server.sookdak.dto.res.post.PostDetailResponseDto;
 import server.sookdak.dto.res.post.PostDetailResponseDto.PostDetail;
 import server.sookdak.dto.res.post.PostListResponseDto;
+import server.sookdak.dto.res.post.ScrapListResponseDto;
 import server.sookdak.exception.CustomException;
 import server.sookdak.repository.*;
 import server.sookdak.util.S3Util;
@@ -228,5 +229,19 @@ public class PostService {
                 .collect(Collectors.toList());
 
         return MyPostListResponseDto.of(posts);
+    }
+
+    public ScrapListResponseDto getMyScrap(int page) {
+        String userEmail = SecurityUtil.getCurrentUserEmail();
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        PageRequest pageRequest = PageRequest.of(page, 20);
+        List<ScrapListResponseDto.ScrapList> scrapLists = postScrapRepository.findAllByUserOrderByCreatedAtDesc(user, pageRequest).stream()
+                .map(ScrapListResponseDto.ScrapList::new)
+                .collect(Collectors.toList());
+
+        return ScrapListResponseDto.of(scrapLists);
+
     }
 }


### PR DESCRIPTION
## 작업사항
게시판 조회할 때 즐겨찾기 많은 순서대로 노출될 수 있도록 수정했습니다.
만약 즐겨찾는 사람 수가 동일하다면 더 먼저 만들어진 게시판이 상위에 노출돼요.

closed #74 

## 테스트
### 게시판 조회
<img width="739" alt="스크린샷 2022-05-07 오전 2 20 19" src="https://user-images.githubusercontent.com/62243967/167181440-ed72b7b7-b4a0-4d4c-9995-1d3a35c6d591.png">



<img width="366" alt="스크린샷 2022-05-07 오전 2 07 12" src="https://user-images.githubusercontent.com/62243967/167180087-517e07c0-0e6f-431c-83c1-1722c918499c.png">


아니 내가 이전 이슈에서 커밋한거 왜 같이 뜨지
