### PR TITLE
[FEAT] 댓글 공감 API

### DIFF
--- a/src/main/java/server/sookdak/api/CommentApi.java
+++ b/src/main/java/server/sookdak/api/CommentApi.java
@@ -5,10 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import server.sookdak.dto.req.CommentSaveRequestDto;
-import server.sookdak.dto.res.comment.CommentListResponse;
-import server.sookdak.dto.res.comment.CommentListResponseDto;
-import server.sookdak.dto.res.comment.CommentResponse;
-import server.sookdak.dto.res.comment.CommentResponseDto;
+import server.sookdak.dto.res.comment.*;
 import server.sookdak.service.CommentService;
 import server.sookdak.util.S3Util;
 
@@ -26,20 +23,20 @@ public class CommentApi {
     private final S3Util s3Util;
 
     @PostMapping("/{postId}/{parent}/save")
-    public ResponseEntity<CommentResponse> saveComment(@PathVariable Long postId, @PathVariable Long parent, @Valid @ModelAttribute CommentSaveRequestDto commentSaveRequestDto) throws IOException {
+    public ResponseEntity<CommentDetailResponse> saveComment(@PathVariable Long postId, @PathVariable Long parent, @Valid @ModelAttribute CommentSaveRequestDto commentSaveRequestDto) throws IOException {
         String imageURL = null;
         if (commentSaveRequestDto.getImage() != null) {
             imageURL = s3Util.commentUpload(commentSaveRequestDto.getImage());
         }
-        CommentResponseDto responseDto = commentService.saveComment(commentSaveRequestDto, postId, parent, imageURL);
-        return CommentResponse.newResponse(COMMENT_SAVE_SUCCESS, responseDto);
+        CommentDetailResponseDto responseDto = commentService.saveComment(commentSaveRequestDto, postId, parent, imageURL);
+        return CommentDetailResponse.newResponse(COMMENT_SAVE_SUCCESS, responseDto);
     }
 
     @DeleteMapping("/{commentId}")
     public ResponseEntity<CommentResponse> deleteComment(@PathVariable Long commentId) {
         commentService.deleteComment(commentId);
 
-        return CommentResponse.newDeleteResponse(COMMENT_DELETE_SUCCESS);
+        return CommentResponse.newResponse(COMMENT_DELETE_SUCCESS);
     }
 
     @GetMapping("/{postId}")
@@ -49,4 +46,14 @@ public class CommentApi {
         return CommentListResponse.newResponse(COMMENT_LIST_READ_SUCCESS, responseDto);
     }
 
+    @PostMapping("/{commentId}/like")
+    public ResponseEntity<CommentResponse> commentLike(@PathVariable Long commentId) {
+        boolean response = commentService.clickCommentLike(commentId);
+        if(response) {
+            return CommentResponse.newResponse(LIKE_SUCCESS);
+        } else{
+            return CommentResponse.newResponse(LIKE_CANCEL_SUCCESS);
+        }
+
+    }
 }

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -27,8 +27,8 @@ public enum SuccessCode {
     STAR_SUCCESS(OK, "게시판 즐겨찾기에 성공했습니다."),
     STAR_CANCEL_SUCCESS(OK, "게시판 즐겨찾기 취소에 성공했습니다."),
     STAR_INFO_SUCCESS(OK, "게시판 즐겨찾기 조회에 성공했습니다."),
-    LIKE_SUCCESS(OK, "게시글 공감에 성공했습니다."),
-    LIKE_CANCEL_SUCCESS(OK, "게시글 공감 취소에 성공했습니다."),
+    LIKE_SUCCESS(OK, "공감에 성공했습니다."),
+    LIKE_CANCEL_SUCCESS(OK, "공감 취소에 성공했습니다."),
 
     HOME_INFO_SUCCESS(OK, "홈 조회에 성공했습니다."),
 

--- a/src/main/java/server/sookdak/domain/Comment.java
+++ b/src/main/java/server/sookdak/domain/Comment.java
@@ -7,6 +7,8 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -37,6 +39,9 @@ public class Comment {
 
     @OneToOne(mappedBy = "comment", cascade = CascadeType.ALL)
     private CommentImage image;
+
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL)
+    private List<CommentLike> likes = new ArrayList<>();
 
     public static Comment createComment(User user, Post post, Long parent, String content, String createdAt){
         Comment comment = new Comment();

--- a/src/main/java/server/sookdak/domain/CommentLike.java
+++ b/src/main/java/server/sookdak/domain/CommentLike.java
@@ -1,0 +1,37 @@
+package server.sookdak.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentLike {
+
+    @EmbeddedId
+    private UserCommentId userCommentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    @MapsId("userId")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    @MapsId("commentId")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Comment comment;
+
+    public static CommentLike createCommentLike(User user, Comment comment) {
+        CommentLike commentLike = new CommentLike();
+        commentLike.userCommentId = new UserCommentId(user.getUserId(), comment.getCommentId());
+        commentLike.user = user;
+        commentLike.comment = comment;
+        return commentLike;
+    }
+}

--- a/src/main/java/server/sookdak/domain/UserCommentId.java
+++ b/src/main/java/server/sookdak/domain/UserCommentId.java
@@ -1,0 +1,21 @@
+package server.sookdak.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserCommentId implements Serializable {
+    private Long userId;
+    private Long commentId;
+
+    public UserCommentId(Long userId, Long commentId) {
+        this.userId = userId;
+        this.commentId = commentId;
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/comment/CommentDetailResponse.java
+++ b/src/main/java/server/sookdak/dto/res/comment/CommentDetailResponse.java
@@ -1,0 +1,29 @@
+package server.sookdak.dto.res.comment;
+
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+
+@Getter
+public class CommentDetailResponse extends BaseResponse {
+    CommentDetailResponseDto data;
+
+    private CommentDetailResponse(Boolean success, String message, CommentDetailResponseDto data){
+        super(success, message);
+        this.data = data;
+    }
+
+
+    public static CommentDetailResponse of(Boolean success, String message, CommentDetailResponseDto data) {
+
+        return new CommentDetailResponse(success, message, data);
+    }
+
+
+    public static ResponseEntity<CommentDetailResponse> newResponse(SuccessCode code, CommentDetailResponseDto data) {
+        CommentDetailResponse response = CommentDetailResponse.of(true, code.getMessage(), data);
+        return new ResponseEntity<>(response, code.getStatus());
+    }
+
+}

--- a/src/main/java/server/sookdak/dto/res/comment/CommentDetailResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/comment/CommentDetailResponseDto.java
@@ -4,27 +4,31 @@ import lombok.Getter;
 import server.sookdak.domain.Comment;
 
 @Getter
-public class CommentResponseDto {
+public class CommentDetailResponseDto {
     private int commentOrder;
     private Long commentId;
     private Long parent;
     private String content;
     private String imageURL;
+    private int likes;
     private String createdAt;
 
 
-    private CommentResponseDto(int commentOrder, Comment entity, String imageURL) {
+
+    private CommentDetailResponseDto(int commentOrder, Comment entity, String imageURL) {
         this.commentOrder = commentOrder;
         this.commentId = entity.getCommentId();
         this.parent = entity.getParent();
         this.content = entity.getContent();
         this.imageURL = imageURL;
+        this.likes = entity.getLikes().size();
         this.createdAt = entity.getCreatedAt();
+
 
     }
 
-    public static CommentResponseDto of(int commentOrder, Comment entity, String imageURL) {
-        return new CommentResponseDto(commentOrder, entity,imageURL);
+    public static CommentDetailResponseDto of(int commentOrder, Comment entity, String imageURL) {
+        return new CommentDetailResponseDto(commentOrder, entity,imageURL);
     }
 }
 

--- a/src/main/java/server/sookdak/dto/res/comment/CommentListResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/comment/CommentListResponseDto.java
@@ -28,8 +28,11 @@ public class CommentListResponseDto {
         private Long parent;
         private String content;
         private String imageURL;
+        private int likes;
         private String createdAt;
         private List<CommentList> reply;
+
+
 
 
         public static CommentList of(Comment comment, int commentOrder, List<CommentList> reply) {
@@ -43,7 +46,9 @@ public class CommentListResponseDto {
                 commentList.imageURL = comment.getImage().getUrl();
             }
             commentList.createdAt = comment.getCreatedAt();
+            commentList.likes = comment.getLikes().size();
             commentList.reply = reply;
+
 
             return commentList;
         }
@@ -59,6 +64,7 @@ public class CommentListResponseDto {
                 commentList.imageURL = comment.getImage().getUrl();
             }
             commentList.createdAt = comment.getCreatedAt();
+            commentList.likes = comment.getLikes().size();
 
             return commentList;
         }

--- a/src/main/java/server/sookdak/dto/res/comment/CommentResponse.java
+++ b/src/main/java/server/sookdak/dto/res/comment/CommentResponse.java
@@ -7,32 +7,15 @@ import server.sookdak.dto.BaseResponse;
 
 @Getter
 public class CommentResponse extends BaseResponse {
-    CommentResponseDto data;
-
-    private CommentResponse(Boolean success, String message, CommentResponseDto data){
-        super(success, message);
-        this.data = data;
-    }
 
     private CommentResponse(Boolean success, String message){
         super(success, message);
     }
-
-    public static CommentResponse of(Boolean success, String message, CommentResponseDto data) {
-
-        return new CommentResponse(success, message, data);
-    }
-
-    public static CommentResponse ofDelete(Boolean success, String message){
+    public static CommentResponse of(Boolean success, String message) {
         return new CommentResponse(success, message);
     }
 
-    public static ResponseEntity<CommentResponse> newResponse(SuccessCode code, CommentResponseDto data) {
-        CommentResponse response = CommentResponse.of(true, code.getMessage(), data);
-        return new ResponseEntity(response, code.getStatus());
-    }
-
-    public static ResponseEntity<CommentResponse> newDeleteResponse(SuccessCode code){
-        return new ResponseEntity(CommentResponse.ofDelete(true, code.getMessage()), code.getStatus());
+    public static ResponseEntity<CommentResponse> newResponse(SuccessCode code) {
+        return new ResponseEntity<>(CommentResponse.of(true, code.getMessage()), code.getStatus());
     }
 }

--- a/src/main/java/server/sookdak/repository/CommentLikeRepository.java
+++ b/src/main/java/server/sookdak/repository/CommentLikeRepository.java
@@ -1,0 +1,13 @@
+package server.sookdak.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.sookdak.domain.Comment;
+import server.sookdak.domain.CommentLike;
+import server.sookdak.domain.User;
+import server.sookdak.domain.UserCommentId;
+
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, UserCommentId> {
+    Optional<CommentLike> findByUserAndComment(User user, Comment comment);
+}

--- a/src/main/java/server/sookdak/service/CommentService.java
+++ b/src/main/java/server/sookdak/service/CommentService.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import server.sookdak.domain.*;
 import server.sookdak.dto.req.CommentSaveRequestDto;
 import server.sookdak.dto.res.comment.CommentListResponseDto;
-import server.sookdak.dto.res.comment.CommentResponseDto;
+import server.sookdak.dto.res.comment.CommentDetailResponseDto;
 import server.sookdak.exception.CustomException;
 import server.sookdak.repository.*;
 import server.sookdak.util.S3Util;
@@ -31,9 +31,10 @@ public class CommentService {
     private final CommentImageRepository commentImageRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final CommentLikeRepository commentLikeRepository;
     private final S3Util s3Util;
 
-    public CommentResponseDto saveComment(CommentSaveRequestDto commentSaveRequestDto, Long postId, Long parent, String imageURL) {
+    public CommentDetailResponseDto saveComment(CommentSaveRequestDto commentSaveRequestDto, Long postId, Long parent, String imageURL) {
         String userEmail = SecurityUtil.getCurrentUserEmail();
         User user = userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -66,7 +67,7 @@ public class CommentService {
             commentIdentifierRepository.save(commentIdentifier);
         }
 
-        return CommentResponseDto.of(commentIdentifier.getCommentOrder(), comment, imageURL);
+        return CommentDetailResponseDto.of(commentIdentifier.getCommentOrder(), comment, imageURL);
     }
 
     public void deleteComment(Long commentId){
@@ -102,5 +103,28 @@ public class CommentService {
                                         .collect(Collectors.toList())))
                 .collect(Collectors.toList());
         return CommentListResponseDto.of(comments);
+    }
+
+    public boolean clickCommentLike(Long commentId){
+        String userEmail = SecurityUtil.getCurrentUserEmail();
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(()-> new CustomException(COMMENT_NOT_FOUND));
+
+        if (comment.getUser() == user) {
+            throw new CustomException(LIKE_DENIED);
+        }
+
+        Optional<CommentLike> existCommentLike = commentLikeRepository.findByUserAndComment(user, comment);
+        if(existCommentLike.isPresent()) {
+            commentLikeRepository.delete(existCommentLike.get());
+            return false;
+        } else {
+            CommentLike commentLike = CommentLike.createCommentLike(user,comment);
+            commentLikeRepository.save(commentLike);
+            return true;
+        }
     }
 }


### PR DESCRIPTION
## 작업사항
댓글 공감 API를 만들었습니다~!

success code 재활용하려고 LIKE_SUCCESS / LIKE_CANCEL_SUCCESS 를 게시글 공감과 댓글 공감 두 api에서 재활용 할 수 있도록 수정했고
원래 commentResponse에서 data가 있는것과 없는것 두 개를 생성자 나눠서 썼는데 그냥 나뉘어져 있는게 깔끔해서 
commentResponse는 데이터 없는거로 하고 commentDetailResponse를 따로 만들어서 data 있는 애들은 이거 쓸 수 있도록 변경했어요
본인이 쓴 댓글은 공감 못하게 했고, 댓글 조회에도 댓글 공감수 필드추가 했습니다! 
공감 있어도 댓글 삭제되는것 까지 확인했어요!

closed #82 

## 테스트
### 댓글 공감 API
<img width="604" alt="스크린샷 2022-05-15 오전 12 43 51" src="https://user-images.githubusercontent.com/62243967/168439556-56038798-0562-4d01-88ec-b17aab22441e.png">

### 댓글 공감 취소
<img width="601" alt="스크린샷 2022-05-15 오전 12 43 57" src="https://user-images.githubusercontent.com/62243967/168439566-2db3e986-9274-4cb0-8e84-3a611b9789b6.png">

### 댓글 조회
<img width="583" alt="스크린샷 2022-05-15 오전 12 43 15" src="https://user-images.githubusercontent.com/62243967/168439575-e195ec7b-a2d6-450c-b210-0ad834b1adba.png">

