### PR TITLE
[FIX] 게시글 상세조회 API 수정

### DIFF
--- a/src/main/java/server/sookdak/dto/res/post/PostDetailResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/post/PostDetailResponseDto.java
@@ -28,8 +28,10 @@ public class PostDetailResponseDto {
         private int comments;
         private List<String> images;
         private boolean writer;
+        private boolean userLiked;
+        private boolean userScrapped;
 
-        public PostDetail(String content, String createdAt, int likes, int scraps, int comments, List<String> images, boolean writer) {
+        public PostDetail(String content, String createdAt, int likes, int scraps, int comments, List<String> images, boolean writer, boolean userLiked, boolean userScrapped) {
             this.content = content;
             this.createdAt = createdAt;
             this.likes = likes;
@@ -37,6 +39,8 @@ public class PostDetailResponseDto {
             this.comments = comments;
             this.images = images;
             this.writer = writer;
+            this.userLiked = userLiked;
+            this.userScrapped = userScrapped;
         }
     }
 }

--- a/src/main/java/server/sookdak/repository/PostLikeRepository.java
+++ b/src/main/java/server/sookdak/repository/PostLikeRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 public interface PostLikeRepository extends JpaRepository<PostLike, UserPostId> {
 
     Optional<PostLike> findByUserAndPost(User user, Post post);
+
+    boolean existsByUserAndPost(User user, Post post);
 }

--- a/src/main/java/server/sookdak/repository/PostScrapRepository.java
+++ b/src/main/java/server/sookdak/repository/PostScrapRepository.java
@@ -16,4 +16,6 @@ public interface PostScrapRepository extends JpaRepository<PostScrap, UserPostId
     int countByPost(Post post);
 
     List<PostScrap> findAllByUserOrderByCreatedAtDesc(User user, Pageable page);
+
+    boolean existsByUserAndPost(User user, Post post);
 }

--- a/src/main/java/server/sookdak/service/PostService.java
+++ b/src/main/java/server/sookdak/service/PostService.java
@@ -134,7 +134,11 @@ public class PostService {
             images.add(image.getUrl());
         }
 
-        PostDetail postDetail = new PostDetail(post.getContent(), post.getCreatedAt(), post.getLikes().size(), postScrapRepository.countByPost(post), post.getComments().size(), images, post.getUser().equals(user));
+        boolean userLiked = postLikeRepository.existsByUserAndPost(user, post);
+
+        boolean userScrapped = postScrapRepository.existsByUserAndPost(user, post);
+
+        PostDetail postDetail = new PostDetail(post.getContent(), post.getCreatedAt(), post.getLikes().size(), postScrapRepository.countByPost(post), post.getComments().size(), images, post.getUser().equals(user), userLiked, userScrapped);
 
         return PostDetailResponseDto.of(postDetail);
     }


### PR DESCRIPTION
## 작업사항
<!-- 이 밑에 작업사항 설명이랑, 리뷰어가 어떤 부분 집중하면 좋을지 쓰면 됩니다 -->
게시글 상세조회 할 때 현재 로그인한 유저가 해당 게시글을 스크랩했는지, 공감했는지 여부도 보내주는 걸로 바꿨습니다!
userLiked, userScrapped에 boolean 형태로 보내줍니다
closed #87 

## 테스트
### 게시글 상세조회 SUCCESS
<img width="770" alt="스크린샷 2022-05-19 오후 11 44 50" src="https://user-images.githubusercontent.com/73515587/169326060-e4522442-4dc9-4dda-b6a1-59c06f93db45.png">

