### PR TITLE
[FEAT] 채팅방 생성, 채팅방 전체 목록조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.3.1'
+
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/server/sookdak/api/ChatApi.java
+++ b/src/main/java/server/sookdak/api/ChatApi.java
@@ -1,0 +1,31 @@
+package server.sookdak.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import server.sookdak.dto.req.ChatRoomSaveRequestDto;
+import server.sookdak.dto.res.chat.*;
+import server.sookdak.service.ChatService;
+
+import javax.validation.Valid;
+
+import static server.sookdak.constants.SuccessCode.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/chat")
+public class ChatApi {
+    private final ChatService chatService;
+
+    @GetMapping("/chatroom")
+    public ResponseEntity<ChatRoomListResponse> findAll() {
+        ChatRoomListResponseDto responseDto = chatService.findAllDesc();
+        return ChatRoomListResponse.newResponse(CHATROOM_READ_SUCCESS, responseDto);
+    }
+
+    @PostMapping("/save")
+    public ResponseEntity<ChatRoomResponse> save(@Valid @RequestBody ChatRoomSaveRequestDto chatRoomSaveRequestDto) {
+        ChatRoomResponseDto responseDto = chatService.saveChatRoom(chatRoomSaveRequestDto);
+        return ChatRoomResponse.newResponse(CHATROOM_CREATE_SUCCESS, responseDto);
+    }
+}

--- a/src/main/java/server/sookdak/config/SecurityConfig.java
+++ b/src/main/java/server/sookdak/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/api/star/**").permitAll()
                 .antMatchers("/api/comment/**").permitAll()
                 .antMatchers("/api/lecture/**").permitAll()
+                .antMatchers("/api/chat/**").permitAll()
                 .anyRequest().authenticated() //나머지 요청은 모두 인증 필요
 
                 //JwtFilter를 addFilterBefore로 등록했던 JwtSecurityConfig 클래스 적용

--- a/src/main/java/server/sookdak/config/WebSocketConfig.java
+++ b/src/main/java/server/sookdak/config/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package server.sookdak.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-stomp").setAllowedOrigins("*").withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+
+        registry.enableSimpleBroker("/room");
+        registry.setApplicationDestinationPrefixes("/app");
+
+    }
+}

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -40,7 +40,9 @@ public enum SuccessCode {
 
     LECTURE_READ_SUCCESS(OK, "강의 조회에 성공했습니다."),
 
-    COMMENT_LIST_READ_SUCCESS(OK, "댓글 목록 조회에 성공했습니다.");
+    COMMENT_LIST_READ_SUCCESS(OK, "댓글 목록 조회에 성공했습니다."),
+    CHATROOM_READ_SUCCESS(OK,"채팅방 목록 조회에 성공했습니다."),
+    CHATROOM_CREATE_SUCCESS(OK,"채팅방 생성에 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/server/sookdak/domain/Board.java
+++ b/src/main/java/server/sookdak/domain/Board.java
@@ -1,7 +1,6 @@
 package server.sookdak.domain;
 
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,7 +20,7 @@ public class Board {
     private Long boardId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_Id")
+    @JoinColumn(name = "user_id")
     private User user;
 
     @NotNull(message = "이름을 입력해주세요")

--- a/src/main/java/server/sookdak/domain/Chat.java
+++ b/src/main/java/server/sookdak/domain/Chat.java
@@ -1,0 +1,42 @@
+package server.sookdak.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Chat {
+
+    @Id
+    @Column(name = "chat_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long chatId;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    @OnDelete(action =  OnDeleteAction.CASCADE)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String createdAt;
+
+    public static Chat createChat(User user, ChatRoom chatRoom, String content, String createdAt) {
+        Chat chat = new Chat();
+        chat.user = user;
+        chat.chatRoom = chatRoom;
+        chat.content = content;
+        chat.createdAt = createdAt;
+        return chat;
+    }
+}

--- a/src/main/java/server/sookdak/domain/ChatRoom.java
+++ b/src/main/java/server/sookdak/domain/ChatRoom.java
@@ -1,0 +1,49 @@
+package server.sookdak.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom{
+    @Id
+    @Column(name = "room_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long roomId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @NotNull(message = "이름을 입력해주세요")
+    @Column(length = 20)
+    private String name;
+
+    private String info;
+
+    private String createdAt;
+
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)
+    private List<Chat> chats = new ArrayList<>();
+
+    @ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinTable(name = "chatter", joinColumns = @JoinColumn(name = "room_id"), inverseJoinColumns = @JoinColumn(name = "user_Id"))
+    private List<User> users = new ArrayList<>();
+
+    public static ChatRoom createChatRoom(User user, String name, String info, String createdAt){
+        ChatRoom chatRoom = new ChatRoom();
+        chatRoom.user = user;
+        chatRoom.name = name;
+        chatRoom.info = info;
+        chatRoom.createdAt = createdAt;
+        return chatRoom;
+    }
+
+}

--- a/src/main/java/server/sookdak/dto/req/ChatRoomSaveRequestDto.java
+++ b/src/main/java/server/sookdak/dto/req/ChatRoomSaveRequestDto.java
@@ -1,0 +1,16 @@
+package server.sookdak.dto.req;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomSaveRequestDto {
+    @NotBlank(message = "채팅방 이름이 없습니다.")
+    private String name;
+
+    private String info;
+}

--- a/src/main/java/server/sookdak/dto/res/chat/ChatRoomListResponse.java
+++ b/src/main/java/server/sookdak/dto/res/chat/ChatRoomListResponse.java
@@ -1,0 +1,28 @@
+package server.sookdak.dto.res.chat;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+
+@Getter
+@NoArgsConstructor
+public class ChatRoomListResponse extends BaseResponse {
+
+    ChatRoomListResponseDto data;
+
+    private ChatRoomListResponse(Boolean success, String msg, ChatRoomListResponseDto data) {
+        super(success, msg);
+        this.data = data;
+    }
+
+    public static ChatRoomListResponse of(Boolean success, String msg, ChatRoomListResponseDto data) {
+        return new ChatRoomListResponse(success, msg, data);
+    }
+
+    public static ResponseEntity<ChatRoomListResponse> newResponse(SuccessCode code, ChatRoomListResponseDto data) {
+        ChatRoomListResponse response = ChatRoomListResponse.of(true, code.getMessage(), data);
+        return new ResponseEntity<>(response, code.getStatus());
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/chat/ChatRoomListResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/chat/ChatRoomListResponseDto.java
@@ -1,0 +1,28 @@
+package server.sookdak.dto.res.chat;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.sookdak.domain.ChatRoom;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ChatRoomListResponseDto {
+    private List<ChatRoomList> chatRooms;
+    private ChatRoomListResponseDto(List<ChatRoomList> chatRooms){ this.chatRooms = chatRooms; }
+    public static ChatRoomListResponseDto of(List<ChatRoomList> chatRooms) { return new ChatRoomListResponseDto(chatRooms); }
+
+    @Getter
+    public static class ChatRoomList {
+        private Long roomId;
+        private String name;
+        private String info;
+
+        public ChatRoomList(ChatRoom entity) {
+            this.roomId = entity.getRoomId();
+            this.name = entity.getName();
+            this.info = entity.getInfo();
+        }
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/chat/ChatRoomResponse.java
+++ b/src/main/java/server/sookdak/dto/res/chat/ChatRoomResponse.java
@@ -1,0 +1,27 @@
+package server.sookdak.dto.res.chat;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+
+@Getter
+@NoArgsConstructor
+public class ChatRoomResponse extends BaseResponse {
+    ChatRoomResponseDto data;
+
+    private ChatRoomResponse(Boolean success, String msg, ChatRoomResponseDto data) {
+        super(success,msg);
+        this.data = data;
+    }
+
+    public static ChatRoomResponse of(Boolean success, String msg, ChatRoomResponseDto data) {
+        return new ChatRoomResponse(success, msg, data);
+    }
+
+    public static ResponseEntity<ChatRoomResponse> newResponse(SuccessCode code, ChatRoomResponseDto data) {
+        ChatRoomResponse response =  ChatRoomResponse.of(true, code.getMessage(), data);
+        return new ResponseEntity<>(response, code.getStatus());
+    }
+}

--- a/src/main/java/server/sookdak/dto/res/chat/ChatRoomResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/chat/ChatRoomResponseDto.java
@@ -1,0 +1,11 @@
+package server.sookdak.dto.res.chat;
+
+import lombok.Getter;
+import server.sookdak.domain.ChatRoom;
+
+@Getter
+public class ChatRoomResponseDto {
+    private Long roomId;
+    private ChatRoomResponseDto(ChatRoom entity) { this.roomId = entity.getRoomId(); }
+    public static ChatRoomResponseDto of(ChatRoom entity) { return new ChatRoomResponseDto(entity); }
+}

--- a/src/main/java/server/sookdak/repository/ChatRoomRepository.java
+++ b/src/main/java/server/sookdak/repository/ChatRoomRepository.java
@@ -1,0 +1,13 @@
+package server.sookdak.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import server.sookdak.domain.ChatRoom;
+
+import java.util.List;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    @Query("SELECT c from ChatRoom c ORDER BY c.users.size DESC")
+    List<ChatRoom> findAllDesc();
+}

--- a/src/main/java/server/sookdak/service/ChatService.java
+++ b/src/main/java/server/sookdak/service/ChatService.java
@@ -1,0 +1,52 @@
+package server.sookdak.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.sookdak.domain.ChatRoom;
+import server.sookdak.domain.User;
+import server.sookdak.dto.req.ChatRoomSaveRequestDto;
+import server.sookdak.dto.res.chat.ChatRoomListResponseDto;
+import server.sookdak.dto.res.chat.ChatRoomListResponseDto.ChatRoomList;
+import server.sookdak.dto.res.chat.ChatRoomResponseDto;
+import server.sookdak.exception.CustomException;
+
+import server.sookdak.repository.ChatRoomRepository;
+import server.sookdak.repository.UserRepository;
+import server.sookdak.util.SecurityUtil;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static server.sookdak.constants.ExceptionCode.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatService {
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public ChatRoomListResponseDto findAllDesc(){
+        List<ChatRoomList> rooms = chatRoomRepository.findAllDesc().stream()
+                .map(ChatRoomList::new)
+                .collect(Collectors.toList());
+        return ChatRoomListResponseDto.of(rooms);
+    }
+
+    public ChatRoomResponseDto saveChatRoom(ChatRoomSaveRequestDto chatRoomSaveRequestDto) {
+        String userEmail = SecurityUtil.getCurrentUserEmail();
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        ChatRoom chatRoom = ChatRoom.createChatRoom(user, chatRoomSaveRequestDto.getName(), chatRoomSaveRequestDto.getInfo(), LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm")));
+        chatRoomRepository.save(chatRoom);
+
+        return ChatRoomResponseDto.of(chatRoom);
+
+    }
+
+}


### PR DESCRIPTION
## 작업사항
웹소켓 의존성 주입하고 웹소켓config 추가했습니다.
채팅방 이름이 없으면 fail 뜨게했고 이름은 있는데 설명이 없어도 만들어집니다
그리구 이름 중복 검사 안합니다 !
채팅방 만들고 나면 바로 그 채팅방으로 들어가거나 ,,, 아니면 내가 입장해있는 채팅방 목록에 떠야하니까 
일단 data를 roomId 로 해놨어요

closed #76 

## 테스트
### 채팅방 생성 API 성공
<img width="662" alt="스크린샷 2022-05-21 오후 5 07 54" src="https://user-images.githubusercontent.com/62243967/169642902-4365e912-452e-4daa-8e4b-1614032f38f4.png">

<img width="612" alt="스크린샷 2022-05-21 오후 5 20 17" src="https://user-images.githubusercontent.com/62243967/169642922-203e1a7a-55bd-4b98-bbce-20bbfd19a3f4.png">

### 채팅방 전체 목록 조회 API 성공
<img width="602" alt="스크린샷 2022-05-21 오후 5 08 10" src="https://user-images.githubusercontent.com/62243967/169642916-218fe0a8-f559-49e4-bf51-d4a15ad51dd0.png">

### fail - 채팅방 이름 없음
<img width="667" alt="스크린샷 2022-05-21 오후 5 19 45" src="https://user-images.githubusercontent.com/62243967/169642931-f76aa6c8-85cb-4044-8dc1-7e18747cf219.png">


