### PR TITLE
[FIX] 댓글 조회 API 수정

### DIFF
--- a/src/main/java/server/sookdak/dto/res/comment/CommentListResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/comment/CommentListResponseDto.java
@@ -29,14 +29,15 @@ public class CommentListResponseDto {
         private String content;
         private String imageURL;
         private int likes;
+        private boolean writer;
+        private boolean userLiked;
         private String createdAt;
         private List<CommentList> reply;
 
 
 
 
-        public static CommentList of(Comment comment, int commentOrder, List<CommentList> reply) {
-
+        public static CommentList of(Comment comment, int commentOrder, boolean writer, boolean userLiked, List<CommentList> reply) {
             CommentList commentList = new CommentList();
             commentList.commentOrder = commentOrder;
             commentList.commentId = comment.getCommentId();
@@ -47,13 +48,15 @@ public class CommentListResponseDto {
             }
             commentList.createdAt = comment.getCreatedAt();
             commentList.likes = comment.getLikes().size();
+            commentList.writer = writer;
+            commentList.userLiked = userLiked;
             commentList.reply = reply;
 
 
             return commentList;
         }
 
-        public static CommentList createReply(Comment comment, int commentOrder) {
+        public static CommentList createReply(Comment comment, int commentOrder, boolean writer, boolean userLiked) {
 
             CommentList commentList = new CommentList();
             commentList.commentOrder = commentOrder;
@@ -65,6 +68,8 @@ public class CommentListResponseDto {
             }
             commentList.createdAt = comment.getCreatedAt();
             commentList.likes = comment.getLikes().size();
+            commentList.writer = writer;
+            commentList.userLiked = userLiked;
 
             return commentList;
         }

--- a/src/main/java/server/sookdak/repository/CommentLikeRepository.java
+++ b/src/main/java/server/sookdak/repository/CommentLikeRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, UserCommentId> {
     Optional<CommentLike> findByUserAndComment(User user, Comment comment);
+
+    boolean existsByUserAndComment(User user, Comment comment);
 }


### PR DESCRIPTION
## 작업사항
댓글 상세조회시 내가 작성했는지 작성여부랑, 공감했는지 공감여부 같이 띄웁니다.


## 테스트
### 댓글조회 성공
<img width="896" alt="스크린샷 2022-05-31 오후 2 53 00" src="https://user-images.githubusercontent.com/62243967/171102693-e59153eb-c072-4bfe-b28f-47cfc0f8d6b6.png">

"commentOrder": 2,
                "commentId": 94,
                "parent": 0,
                "content": "귀여운 다인이…",
                "imageURL": null,
                "likes": 1,
                "writer": false,
                "userLiked": true,
                "createdAt": "2022/05/23 00:35",
                "reply": [
                    {
                        "commentOrder": 1,
                        "commentId": 101,
                        "parent": 94,
                        "content": "수연이댓글에 다인이가 답글 달",
                        "imageURL": null,
                        "likes": 0,
                        "writer": true,
                        "userLiked": false,
                        "createdAt": "2022/05/31 14:58",
                        "reply": null
                    }
                ]

답댓글에도 반영 잘 됩니다

closed #92 