### PR TITLE
[FIX] 댓글 조회 API 수정

### DIFF
--- a/src/main/java/server/sookdak/domain/Comment.java
+++ b/src/main/java/server/sookdak/domain/Comment.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,7 +34,7 @@ public class Comment {
     @Column(length = 2000)
     private String content;
 
-    private String createdAt;
+    private LocalDateTime createdAt;
 
     private Long parent;
 
@@ -43,7 +44,7 @@ public class Comment {
     @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL)
     private List<CommentLike> likes = new ArrayList<>();
 
-    public static Comment createComment(User user, Post post, Long parent, String content, String createdAt){
+    public static Comment createComment(User user, Post post, Long parent, String content, LocalDateTime createdAt){
         Comment comment = new Comment();
         comment.user = user;
         comment.post = post;
@@ -52,6 +53,4 @@ public class Comment {
         comment.createdAt = createdAt;
         return comment;
     }
-
-
 }

--- a/src/main/java/server/sookdak/dto/res/comment/CommentDetailResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/comment/CommentDetailResponseDto.java
@@ -1,9 +1,14 @@
 package server.sookdak.dto.res.comment;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import server.sookdak.domain.Comment;
 
+import java.time.LocalDateTime;
+
 @Getter
+@NoArgsConstructor
 public class CommentDetailResponseDto {
     private int commentOrder;
     private Long commentId;
@@ -11,9 +16,8 @@ public class CommentDetailResponseDto {
     private String content;
     private String imageURL;
     private int likes;
-    private String createdAt;
-
-
+    @JsonFormat(pattern = "yyyy/MM/dd HH:mm", timezone = "Asia/Seoul")
+    private LocalDateTime createdAt;
 
     private CommentDetailResponseDto(int commentOrder, Comment entity, String imageURL) {
         this.commentOrder = commentOrder;
@@ -23,12 +27,10 @@ public class CommentDetailResponseDto {
         this.imageURL = imageURL;
         this.likes = entity.getLikes().size();
         this.createdAt = entity.getCreatedAt();
-
-
     }
 
     public static CommentDetailResponseDto of(int commentOrder, Comment entity, String imageURL) {
-        return new CommentDetailResponseDto(commentOrder, entity,imageURL);
+        return new CommentDetailResponseDto(commentOrder, entity, imageURL);
     }
 }
 

--- a/src/main/java/server/sookdak/dto/res/comment/CommentListResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/comment/CommentListResponseDto.java
@@ -1,11 +1,12 @@
 package server.sookdak.dto.res.comment;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import server.sookdak.domain.Comment;
 
+import java.time.LocalDateTime;
 import java.util.List;
-
 
 @Getter
 @NoArgsConstructor
@@ -22,7 +23,7 @@ public class CommentListResponseDto {
 
     @Getter
     @NoArgsConstructor
-    public static class CommentList {
+    public static class CommentList implements Comparable<CommentList> {
         private int commentOrder;
         private Long commentId;
         private Long parent;
@@ -31,11 +32,9 @@ public class CommentListResponseDto {
         private int likes;
         private boolean writer;
         private boolean userLiked;
-        private String createdAt;
+        @JsonFormat(pattern = "yyyy/MM/dd HH:mm", timezone = "Asia/Seoul")
+        private LocalDateTime createdAt;
         private List<CommentList> reply;
-
-
-
 
         public static CommentList of(Comment comment, int commentOrder, boolean writer, boolean userLiked, List<CommentList> reply) {
             CommentList commentList = new CommentList();
@@ -51,13 +50,10 @@ public class CommentListResponseDto {
             commentList.writer = writer;
             commentList.userLiked = userLiked;
             commentList.reply = reply;
-
-
             return commentList;
         }
 
         public static CommentList createReply(Comment comment, int commentOrder, boolean writer, boolean userLiked) {
-
             CommentList commentList = new CommentList();
             commentList.commentOrder = commentOrder;
             commentList.commentId = comment.getCommentId();
@@ -70,10 +66,20 @@ public class CommentListResponseDto {
             commentList.likes = comment.getLikes().size();
             commentList.writer = writer;
             commentList.userLiked = userLiked;
-
             return commentList;
         }
+
+        public static CommentList createNull(List<CommentList> reply, Long commentId) {
+            CommentList commentList = new CommentList();
+            commentList.commentId = commentId;
+            commentList.parent = 0L;
+            commentList.reply = reply;
+            return commentList;
+        }
+
+        @Override
+        public int compareTo(CommentList o) {
+            return Long.compare(commentId, o.commentId);
+        }
     }
-
-
 }

--- a/src/main/java/server/sookdak/repository/CommentRepository.java
+++ b/src/main/java/server/sookdak/repository/CommentRepository.java
@@ -20,5 +20,10 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
     @Query("select c from Comment c where c.parent = ?1")
     List<Comment> findAllByParent(Long parent);
 
+    @Query("select distinct c.parent from Comment c where c.parent <> 0 and c.post=?1")
+    List<Long> findReplies(Post post);
+
+    @Query("select count(c) from Comment c where c.commentId=?1")
+    int countReplyParent(Long parent);
 }
 


### PR DESCRIPTION
## 작업사항
<!-- 이 밑에 작업사항 설명이랑, 리뷰어가 어떤 부분 집중하면 좋을지 쓰면 됩니다 -->
1. Comment 도메인에 createdAt이 원래 String이었는데 LocalDateTime으로 바꿨어요!!
db table에서도 수정된 것 확인했고, 그래서 조회 부분 DTO에 포맷 설정하는 어노테이션 붙였어요 (JsonFormat)

2. 삭제된 댓글의 대댓글 조회될 수 있도록 바꿨습니다!
쿼리를 따로 날려서 List에 추가하는 방법이라서, CommentList class에 Comparable implements해서 나중에 정렬해주는 식으로 구현했어요

closed #108 

## 테스트
### 댓글 조회 SUCCESS
<img width="831" alt="스크린샷 2022-06-01 오후 12 04 35" src="https://user-images.githubusercontent.com/73515587/171319679-3a413363-b809-428c-9f6f-431f056f3252.png">
