### PR TITLE
[FEAT] 채팅방 입장 API, [FIX] 채팅방 목록조회 API 수정

### DIFF
--- a/src/main/java/server/sookdak/api/ChatApi.java
+++ b/src/main/java/server/sookdak/api/ChatApi.java
@@ -42,5 +42,12 @@ public class ChatApi {
         return ChatResponseDto.of(chat);
     }
 
+    @PostMapping("/join/{roomId}")
+    public ResponseEntity<ChatRoomResponse> roomJoin(@PathVariable Long roomId) {
+        ChatRoomResponseDto responseDto = chatService.joinChatRoom(roomId);
+        return ChatRoomResponse.newResponse(CHATROOM_JOIN_SUCCESS, responseDto);
+
+    }
+
 
 }

--- a/src/main/java/server/sookdak/config/WebSocketConfig.java
+++ b/src/main/java/server/sookdak/config/WebSocketConfig.java
@@ -14,7 +14,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws-stomp").withSockJS();
+        registry.addEndpoint("/ws-stomp").setAllowedOrigins("*").withSockJS();
     }
 
     @Override

--- a/src/main/java/server/sookdak/constants/ExceptionCode.java
+++ b/src/main/java/server/sookdak/constants/ExceptionCode.java
@@ -48,7 +48,8 @@ public enum ExceptionCode {
     DUPLICATE_BOARD_NAME(CONFLICT, "이미 해당 이름을 가진 게시판이 있습니다."),
     ALREADY_WARN(CONFLICT, "이미 신고한 게시글입니다."),
     ALREADY_ADD_LECTURE(CONFLICT, "이미 추가한 강의입니다."),
-    DUPLICATE_LECTURE_DATETIME(CONFLICT, "이미 해당 시간에 추가된 강의가 있습니다.");
+   DUPLICATE_LECTURE_DATETIME(CONFLICT, "이미 해당 시간에 추가된 강의가 있습니다."),
+    ALREADY_JOIN(CONFLICT, "이미 참여중인 채팅방입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -52,7 +52,8 @@ public enum SuccessCode {
 
     COMMENT_LIST_READ_SUCCESS(OK, "댓글 목록 조회에 성공했습니다."),
     CHATROOM_READ_SUCCESS(OK,"채팅방 목록 조회에 성공했습니다."),
-    CHATROOM_CREATE_SUCCESS(OK,"채팅방 생성에 성공했습니다.");
+    CHATROOM_CREATE_SUCCESS(OK,"채팅방 생성에 성공했습니다."),
+    CHATROOM_JOIN_SUCCESS(OK, "채팅방 입장에 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/server/sookdak/dto/res/chat/ChatRoomListResponseDto.java
+++ b/src/main/java/server/sookdak/dto/res/chat/ChatRoomListResponseDto.java
@@ -3,6 +3,7 @@ package server.sookdak.dto.res.chat;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import server.sookdak.domain.ChatRoom;
+import server.sookdak.domain.User;
 
 import java.util.List;
 
@@ -18,11 +19,19 @@ public class ChatRoomListResponseDto {
         private Long roomId;
         private String name;
         private String info;
+        private int users;
+        private boolean status;
 
-        public ChatRoomList(ChatRoom entity) {
-            this.roomId = entity.getRoomId();
-            this.name = entity.getName();
-            this.info = entity.getInfo();
+
+        public static ChatRoomList of(ChatRoom chatRoom, boolean status) {
+            ChatRoomList chatRoomList = new ChatRoomList();
+            chatRoomList.roomId = chatRoom.getRoomId();
+            chatRoomList.name = chatRoom.getName();
+            chatRoomList.info = chatRoom.getInfo();
+            chatRoomList.users= chatRoom.getUsers().size();
+            chatRoomList.status = status;
+
+            return chatRoomList;
         }
     }
 }


### PR DESCRIPTION
## 작업사항
웹소켓 cors 를 전체허용으로 하기위해 websocketconfig 수정했고,
채팅방 목록 조회시 status : true/ false 로 참여중인지 아닌지를 보내기 위해서 수정했습니다.
그리고 채팅방에 참여중인 인원수도 같이 보내야해서 그렇게 수정했고
프론트쪽에서 인원수가 많은 순서대로 채팅방 목록 정렬 해달라고 해서 그렇게 했어요!
이슈를 두개로 나눠서 했어야 했는데 ,,, 깜박해버렸씀다ㅠㅠ

채팅방 입장 API는 사실 웹소켓 이용하면 굳이 안만들어도 되는데,,, 지금 필요해서 일단 급한대로 만들었씀다.. 

closed #109 

## 테스트
### 채팅방 입장 API 성공
<img width="624" alt="스크린샷 2022-06-06 오후 8 46 58" src="https://user-images.githubusercontent.com/62243967/172156015-fbf0368f-d594-497b-b4cd-2e7178d0f044.png">

### 채팅방 입장 실패 (없는 방을 들어가려고 하면 )
<img width="592" alt="스크린샷 2022-06-06 오후 8 56 34" src="https://user-images.githubusercontent.com/62243967/172156083-6d33a1f6-5ca9-43e3-b80e-ab2fd7cba554.png">

### 채팅방 입장 실패 (이미 참여중인 방을 들어가려고 하면)
<img width="454" alt="스크린샷 2022-06-07 오전 1 56 43" src="https://user-images.githubusercontent.com/62243967/172208504-17fcaf18-a4e5-4e42-9adc-e98aeda1a141.png">



### 채팅방 목록조회 API성공
<img width="596" alt="스크린샷 2022-06-06 오후 8 52 39" src="https://user-images.githubusercontent.com/62243967/172156258-01426ee2-2193-4096-bd96-ae2ba417dedd.png">

