### PR TITLE
[FEAT] 채팅방 퇴장 API

### DIFF
--- a/src/main/java/server/sookdak/api/ChatApi.java
+++ b/src/main/java/server/sookdak/api/ChatApi.java
@@ -49,5 +49,11 @@ public class ChatApi {
 
     }
 
+    @DeleteMapping("/quit/{roomId}")
+    public ResponseEntity<ChatStatusResponse> quitChatRoom(@PathVariable Long roomId) {
+        chatService.quitChatRoom(roomId);
+        return ChatStatusResponse.newResponse(CHATROOM_QUIT_SUCCESS);
+    }
+
 
 }

--- a/src/main/java/server/sookdak/config/SecurityConfig.java
+++ b/src/main/java/server/sookdak/config/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/api/lecture/**").permitAll()
                 .antMatchers("/api/chat/**").permitAll()
                 .antMatchers("/api/message/**").permitAll()
+                .antMatchers("/ws-stomp/**").permitAll()
                 .anyRequest().authenticated() //나머지 요청은 모두 인증 필요
 
                 //JwtFilter를 addFilterBefore로 등록했던 JwtSecurityConfig 클래스 적용

--- a/src/main/java/server/sookdak/constants/SuccessCode.java
+++ b/src/main/java/server/sookdak/constants/SuccessCode.java
@@ -54,7 +54,8 @@ public enum SuccessCode {
     COMMENT_LIST_READ_SUCCESS(OK, "댓글 목록 조회에 성공했습니다."),
     CHATROOM_READ_SUCCESS(OK,"채팅방 목록 조회에 성공했습니다."),
     CHATROOM_CREATE_SUCCESS(OK,"채팅방 생성에 성공했습니다."),
-    CHATROOM_JOIN_SUCCESS(OK, "채팅방 입장에 성공했습니다.");
+    CHATROOM_JOIN_SUCCESS(OK, "채팅방 입장에 성공했습니다."),
+    CHATROOM_QUIT_SUCCESS(OK, "채팅방 퇴장에 성공했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/server/sookdak/dto/res/chat/ChatStatusResponse.java
+++ b/src/main/java/server/sookdak/dto/res/chat/ChatStatusResponse.java
@@ -1,0 +1,16 @@
+package server.sookdak.dto.res.chat;
+
+import org.springframework.http.ResponseEntity;
+import server.sookdak.constants.SuccessCode;
+import server.sookdak.dto.BaseResponse;
+
+public class ChatStatusResponse extends BaseResponse {
+    private ChatStatusResponse(Boolean success, String message) {super(success, message); }
+
+    public static ChatStatusResponse of(Boolean success, String message) { return new ChatStatusResponse(success, message); }
+
+    public static ResponseEntity<ChatStatusResponse> newResponse(SuccessCode code) {
+        return new ResponseEntity<>(ChatStatusResponse.of(true, code.getMessage()), code.getStatus());
+    }
+
+}

--- a/src/main/java/server/sookdak/service/ChatService.java
+++ b/src/main/java/server/sookdak/service/ChatService.java
@@ -84,4 +84,18 @@ public class ChatService {
         return ChatRoomResponseDto.of(chatRoom);
     }
 
+    public void quitChatRoom(Long roomId) {
+        String userEmail = SecurityUtil.getCurrentUserEmail();
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(()-> new CustomException(ROOM_NOT_FOUND));
+        if (chatRoom.getUsers().contains(user)) {
+            chatRoom.getUsers().remove(user);
+        }else {
+            throw new CustomException(ROOM_NOT_FOUND);
+        }
+    }
+
+
 }


### PR DESCRIPTION
## 작업사항
유저가 채팅방 퇴장 하는 api 를 만들었습니다.
나중에 웹소켓 연동하면 아마 바뀔 코드에요ㅠ
지금 일단 테스트 하는 과정에서 좀 필요해서 만들었습니다
채팅방 퇴장 후 채팅방 목록조회 시 status 가  false 로 바뀌는것과, 인원수 제대로 바뀌는지 확인했어요!

## 테스트
### 채팅방 퇴장 성공
<img width="609" alt="스크린샷 2022-06-09 오후 10 35 06" src="https://user-images.githubusercontent.com/62243967/172860312-d183c6e6-f6a6-4a42-b849-d15451041389.png">

### 채팅방 퇴장 실패 ( 참여하고 있지 않은 방을 퇴장하려고 하거나, 없는 방을 퇴장하려고 할 때)
<img width="613" alt="스크린샷 2022-06-09 오후 10 36 48" src="https://user-images.githubusercontent.com/62243967/172860508-ae5b85a4-0aec-4bcc-a8e3-867499745728.png">

closed #118 
